### PR TITLE
v1.4.3: Increased reliability, maintainability and test coverage

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+06/21/2026  Version 1.4.3.0-a:
+		Simplified CLARK classifier dispatch and tightened --kso mode validation.
+		Added unit and regression tests for file helpers, HashTop, and user-facing analysis tools.
+		Hardened abundance, sequence extraction, summary table, and target k-mer distribution edge cases.
 06/21/2026  Version 1.4.2.0-a:
 		RefSeq downloader refactored with dry-run, manifest and provenance outputs.
 		Removed install wrapper; users now build CLARK with "make all".

--- a/Makefile
+++ b/Makefile
@@ -40,14 +40,17 @@ HELPERS := \
 	$(EXE_DIR)/extractSeqs
 
 VARIANTS := $(EXE_DIR)/CLARK $(EXE_DIR)/CLARK-l $(EXE_DIR)/CLARK-S
+UNIT_TESTS := $(EXE_DIR)/unit_file_hash_tests
 
-.PHONY: all helpers variants clean test coverage openmp-status
+.PHONY: all helpers variants unit-tests clean test coverage openmp-status
 
 all: openmp-status helpers variants
 
 helpers: $(HELPERS)
 
 variants: $(VARIANTS)
+
+unit-tests: $(UNIT_TESTS)
 
 openmp-status:
 	@if [ "$(OPENMP_FLAGS)" = "-fopenmp" ]; then \
@@ -98,6 +101,9 @@ $(EXE_DIR)/getTargetSpecificKmersStat: src/file.cc src/getTargetSpecificKmersSta
 $(EXE_DIR)/extractSeqs: src/file.cc src/extractSequences.cc | $(EXE_DIR)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o "$@" $^ $(LDFLAGS)
 
+$(EXE_DIR)/unit_file_hash_tests: tests/unit_file_hash_tests.cc src/file.cc src/file.hh src/HashTop.hh src/dataType.hh src/parameters.hh | $(EXE_DIR)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I. -o "$@" tests/unit_file_hash_tests.cc src/file.cc $(LDFLAGS)
+
 $(BUILD_DIR)/default/.prepared: src/*.cc src/*.hh src/parameters.hh | $(BUILD_DIR)
 	rm -rf "$(BUILD_DIR)/default"
 	mkdir -p "$(BUILD_DIR)/default"
@@ -131,7 +137,7 @@ $(EXE_DIR)/CLARK-l: $(BUILD_DIR)/light/.prepared | $(EXE_DIR)
 $(EXE_DIR)/CLARK-S: $(BUILD_DIR)/spaced/.prepared | $(EXE_DIR)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(OPENMP_FLAGS) -o "$@" $(BUILD_DIR)/spaced/*.cc $(LDFLAGS) $(OPENMP_FLAGS)
 
-test: all
+test: all unit-tests
 	tests/run_tests.sh
 
 coverage:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ CLARK is distributed under the GNU General Public License (GPL) v3. It is free s
 
 ## Releases
 
+### Version 1.4.3 (June 21, 2026)
+- Simplified CLARK classifier dispatch and made `--kso` validation order-independent.
+- Added focused unit/regression tests for file helpers, `HashTop`, and user-facing analysis tools.
+- Hardened abundance, sequence extraction, summary table, and target k-mer distribution edge cases.
+
 ### Version 1.4.2 (June 21, 2026)
 - Refactored RefSeq downloader with dry-run, manifest, and provenance outputs.
 - Removed `scripts/install.sh`; build CLARK with `make all`.

--- a/README_FULL.md
+++ b/README_FULL.md
@@ -1280,6 +1280,8 @@ In the default or express mode, the results format is the following for each lin
 
 ## VERSIONS
 
+Version 1.4.3.0-a	June 21, 2026.
+
 Version 1.4.2.0-a	June 21, 2026.
 
 Version 1.4.1.0-a	June 20, 2026.

--- a/README_FULL.md
+++ b/README_FULL.md
@@ -311,10 +311,11 @@ i.e., the k-mer length and the minimum k-mers frequency (default 0).
 - `scripts/extractSequences.sh`: To extract/filter from the input data, the sequences identified
 to a specific taxon once the classification is done. This can be used for downstream 
 analysis (analysis of contaminants, genome assembly, etc.).
-Parameters are: The taxonomy id (of the taxon to look up), the address of the file 
-containing sequences (fasta/fastq format), the address of the CLARK results file 
-(csv file), and the minimum thresholds for the gamma value and the confidence score 
-(in the case the CLARK results file contains these statistics). 
+Parameters are: The taxonomy id (of the taxon to look up), the address of the file
+containing sequences (fasta/fastq format), the address of the CLARK results file
+(csv file), and the output file prefix. For full/spectrum result files containing
+gamma and confidence statistics, also provide the minimum thresholds for the gamma
+value and the confidence score.
 
 ## INTRODUCTION ON CLARK USAGE
 

--- a/scripts/extractSequences.sh
+++ b/scripts/extractSequences.sh
@@ -18,13 +18,14 @@
 #
 #   Copyright @ The Regents of the University of California. All rights reserved.
 #
-#   extractSequences: To extract sequences from the input data that mapped 
-#		      to a specified taxon.
+#   extractSequences: To extract sequences from the input data that mapped
+#		      to a specified taxon. For full/spectrum reports, pass
+#		      minimum gamma and confidence thresholds after the output prefix.
 #
 
 LDIR=${CLARK_HOME:-$(CDPATH= cd "$(dirname "$0")/.." && pwd -P)}
 
-if [ $# -lt 3 ]; then
+if [ $# -lt 4 ]; then
 "$LDIR/exe/extractSeqs"
 exit
 fi

--- a/scripts/getTargetsKmers_distribution.sh
+++ b/scripts/getTargetsKmers_distribution.sh
@@ -24,16 +24,18 @@
 #  @author: Rachid Ounit, Ph.D.
 #  @project: CLARK, Metagenomic and Genomic Sequences Classification project.
 #  @note: C++/Shell IMPLEMENTATION supported on latest Linux and Mac OS.
-#  getTargetsKmers_distribution.sh: To estimate abundance of target identified (reported
-#			  by taxa name and lineage) with count and proportion 
-#			  (against all reads or classified reads). 
-#			  Filtering options are offered.
+#  getTargetsKmers_distribution.sh: To print the target-specific k-mer distribution
+#			  for the current working database. The minimum k-mer
+#			  frequency defaults to 0 when omitted.
 # 
 
 LDIR=${CLARK_HOME:-$(CDPATH= cd "$(dirname "$0")/.." && pwd -P)}
 
-if [ $# -lt 2 ]; then
-echo "Usage: $0 <k-mer length: integer between 2 and 32> <min k-mers frequency: default is 0>"
+if [ $# -lt 1 ]; then
+echo "Usage: $0 <k-mer length: integer between 2 and 32> [min k-mers frequency: default is 0]"
 exit
+fi
+if [ $# -eq 1 ]; then
+set -- "$1" 0
 fi
 "$LDIR/exe/getTargetSpecificKmersStat" "$LDIR/.settings" "$@"

--- a/src/HashTop.hh
+++ b/src/HashTop.hh
@@ -34,6 +34,7 @@
 #include "./dataType.hh"
 #include<string.h>
 #include<sstream>
+#include<string>
 
 class HashTop
 {
@@ -154,7 +155,7 @@ class HashTop
 			num = m_ITable[t]==m_Token?m_CTable[t]:0;
                         ss << "," << num;
                 }
-                string result = ss.str();
+                std::string result = ss.str();
 		_line = result;
 	}
 

--- a/src/extractSequences.cc
+++ b/src/extractSequences.cc
@@ -156,8 +156,13 @@ int main(int argc, const char** argv)
 	fclose(fdt);
 	///////////////////
 	string TaxidToChk(argv[1]);
-	double minG = atof(argv[5]);
-	double minC = atof(argv[6]);
+	double minG = 0.0;
+	double minC = 0.0;
+	if (isLongReport)
+	{
+		minG = atof(argv[5]);
+		minC = atof(argv[6]);
+	}
 	if (minG > 3.0)
 	{
 		cerr << "No sequence can be assigned with gamma score higher than 3.0 (which is the highest value achieved when using CLARK-S)."<< endl;
@@ -277,5 +282,4 @@ int main(int argc, const char** argv)
 	fout.close();
 	return 0;
 }
-
 

--- a/src/getAbundance.cc
+++ b/src/getAbundance.cc
@@ -292,6 +292,12 @@ int main(int argc, char** argv)
 		exit(1);
 	}
 
+	if (i_deb < 0 || i_end < 0)
+	{
+		cerr << "Please provide one (or several) CLARK output file(s) (CSV format)." << endl;
+		exit(1);
+	}
+
 	FILE * fd = fopen(argv[i_deb], "r");
 	if (fd == NULL)
 	{

--- a/src/getTargetSpecificKmersStat.cc
+++ b/src/getTargetSpecificKmersStat.cc
@@ -79,11 +79,13 @@ int main(int argc, char** argv)
 	string predbfile = ele[1];
 
 	fclose(fd);
-	size_t m_km = atoi(argv[2]);
+	int parsedKmerLength = atoi(argv[2]);
+	int parsedMinCount = atoi(argv[3]);
 	fd = fopen(ftarget.c_str(), "r");
-	size_t minCt = atoi(argv[3]);
+	size_t m_km = (size_t) parsedKmerLength;
+	size_t minCt = (size_t) parsedMinCount;
 	vector<size_t> countKmers;
-	if (m_km < 32 && m_km > 2 && minCt >= 0 && fd != NULL)
+	if (parsedKmerLength >= 2 && parsedKmerLength <= 32 && parsedMinCount >= 0 && fd != NULL)
 	{
 		while (getLineFromFile(fd, line))
 		{

--- a/src/main.cc
+++ b/src/main.cc
@@ -75,6 +75,38 @@ void printUsage()
 	return;
 }
 
+template <typename HKMERr>
+void runClassifier(const size_t& k,
+		const char* targets,
+		const char* folder,
+		const size_t& w,
+		const std::vector<std::string>& DSS,
+		const ITYPE& minT,
+		const bool& tsk,
+		const bool& cLightDB,
+		const bool& spacedK,
+		const size_t& iterKmers,
+		const size_t& cpu,
+		const ITYPE& sfactor,
+		const bool& longR,
+		const bool& ldm,
+		const char* objects,
+		const char* objects2,
+		const char* results,
+		const bool& paired,
+		const size_t& mode,
+		const ITYPE& minO,
+		const bool& kso,
+		const bool& ext)
+{
+	CLARK<HKMERr> classifier(k, targets, folder, w, DSS, minT, tsk, cLightDB, spacedK, iterKmers, cpu, sfactor, longR, ldm);
+	if (paired)
+	{	classifier.run(objects, objects2, results, mode, minO, kso, ext, true);	}
+	else
+	{	classifier.run(objects, results, mode, minO, kso, ext, true);	}
+	exit(0);
+}
+
 int main(int argc, char** argv)
 {
 	if (argc == 2)
@@ -97,7 +129,7 @@ int main(int argc, char** argv)
 	}
 	size_t	k 		= LENGTH, w = 0, mode = 1, cpu = 1, iterKmers = 0;
 	ITYPE minT 		= 0, minO = 0, sfactor = 0;
-	bool cLightDB 		= false, spacedK = false, ldm = false, tsk = false, kso= false, ext = false, isReduced = false, longR =  false;
+	bool cLightDB 		= false, spacedK = false, ldm = false, tsk = false, kso= false, ext = false, longR =  false;
 	int i_targets	 	= -1, i_objects = -1, i_objects2 = -1, i_folder=-1, i_results =-1;
 	std::vector<std::string> DSS;
 
@@ -136,7 +168,6 @@ int main(int argc, char** argv)
 			if (++i >= argc) {cerr << "Please specify the mode!"<< endl; exit(1);    }
 			mode =  atoi(argv[i]);
 			if (mode > 3) {	cerr <<"The mode of execution should be 0 (full), 1 (default), 2 (express) or 3 (colum-based)." << endl; exit(1);}
-			if (mode != 3) {	kso = false;	}
 			continue;
 		}
 		if (val ==   "-n")
@@ -274,35 +305,25 @@ int main(int argc, char** argv)
 	if (w <= max16)
 	{
 		// Use 2Bytes to store each discriminative k-mer
-		CLARK<T16> classifier(k, argv[i_targets], folder.c_str(), w, DSS, minT, tsk, cLightDB, spacedK, iterKmers, cpu, sfactor, longR, ldm);
-		if (paired)
-		{	classifier.run(objects, objects2, argv[i_results], mode, minO, kso, ext, true);	}
-		else
-		{	classifier.run(objects, argv[i_results], mode, minO, kso, ext, true); 	}
-		exit(0);
+		runClassifier<T16>(k, argv[i_targets], folder.c_str(), w, DSS, minT, tsk, cLightDB, spacedK,
+				iterKmers, cpu, sfactor, longR, ldm, objects, objects2, argv[i_results], paired,
+				mode, minO, kso, ext);
 	}
 	if (w <= max32)
 	{
 		// Use 4Bytes to store each discriminative k-mer
-		CLARK<T32> classifier(k, argv[i_targets], folder.c_str(), w, DSS, minT, tsk, cLightDB, spacedK, iterKmers, cpu, sfactor, longR, ldm);
-		if (paired)
-                {       classifier.run(objects, objects2, argv[i_results], mode, minO, kso, ext, true); }
-                else
-                {       classifier.run(objects, argv[i_results], mode, minO, kso, ext, true);   }  
-		exit(0);
+		runClassifier<T32>(k, argv[i_targets], folder.c_str(), w, DSS, minT, tsk, cLightDB, spacedK,
+				iterKmers, cpu, sfactor, longR, ldm, objects, objects2, argv[i_results], paired,
+				mode, minO, kso, ext);
 	}
 	if (w <= MAXK)
 	{
 		// Use 8Bytes to store each discriminative k-mer
-		CLARK<T64> classifier(k, argv[i_targets], folder.c_str(), w, DSS, minT, tsk, cLightDB, spacedK, iterKmers, cpu, sfactor, longR, ldm);
-		if (paired)
-                {       classifier.run(objects, objects2, argv[i_results], mode, minO, kso, ext, true); }
-                else
-                {       classifier.run(objects, argv[i_results], mode, minO, kso, ext, true);   }  
-		exit(0);
+		runClassifier<T64>(k, argv[i_targets], folder.c_str(), w, DSS, minT, tsk, cLightDB, spacedK,
+				iterKmers, cpu, sfactor, longR, ldm, objects, objects2, argv[i_results], paired,
+				mode, minO, kso, ext);
 	}
 	std::cout <<"This version of CLARK does not support k-mer length strictly higher than " << MAXK << std::endl;
 	exit(-1);
 
 }
-

--- a/src/makeSamplesSummaryTables.cc
+++ b/src/makeSamplesSummaryTables.cc
@@ -345,6 +345,37 @@ void DisplaySamples2(const int& topK, const double& abd, const vector<Sample>& S
 	/* Display */
 	ofstream fout("TableSummary_HitCount.csv");
 	string prefix =_isExtended?",,,":"";
+	if (HitCounts.empty())
+	{
+		fout << prefix << "Filenames,"  ;
+		for(size_t t=0; t < Samples.size(); t++)
+		{
+			fout << Samples[t].Name << "," ;
+		}
+		fout << endl;
+		fout << prefix <<"#TotalReads," ;
+		for(size_t t=0; t < Samples.size(); t++)
+		{
+			fout << Samples[t].NReads << "," ;
+		}
+		fout << endl;
+		fout << prefix << "#TotalReadsMapped," ;
+		for(size_t t=0; t < Samples.size(); t++)
+		{
+			fout << Samples[t].NRAssigned << "," ;
+		}
+		fout << endl;
+		if (_isExtended)
+		{	fout << "Domain,TaxonomyID,Name," ;	}
+		fout << "AlphaDiversity,";
+		for(size_t t=0; t < Samples.size(); t++)
+		{
+			fout << Samples[t].ADiversity << "," ;
+		}
+		fout << endl;
+		fout.close();
+		return;
+	}
 	fout << prefix << "Filenames,"  ;
 	for(size_t t=0; t < Samples.size(); t++)
 	{	
@@ -508,4 +539,3 @@ int main(const int argc, const char** argv)
 		return 0;
 	}
 }
-

--- a/src/parameters.hh
+++ b/src/parameters.hh
@@ -30,7 +30,7 @@
 #ifndef PARAMETERS_HH
 #define PARAMETERS_HH
 
-#define VERSION "1.4.2.0-a"
+#define VERSION "1.4.3.0-a"
 
 #define SB              4       
 #define DBCTRESH	4

--- a/src/parameters_hh
+++ b/src/parameters_hh
@@ -30,7 +30,7 @@
 #ifndef PARAMETERS_HH
 #define PARAMETERS_HH
 
-#define VERSION "1.4.2.0-a"
+#define VERSION "1.4.3.0-a"
 
 #define SB              4       
 #define DBCTRESH        4

--- a/src/parameters_shh
+++ b/src/parameters_shh
@@ -30,7 +30,7 @@
 #ifndef PARAMETERS_HH
 #define PARAMETERS_HH
 
-#define VERSION "1.4.2.0-a"
+#define VERSION "1.4.3.0-a"
 
 #define SB              4       
 #define DBCTRESH	8

--- a/tests/coverage_report.sh
+++ b/tests/coverage_report.sh
@@ -21,7 +21,7 @@ command -v gcov >/dev/null 2>&1 || {
 }
 
 make -C "$REPO_DIR" clean
-make -C "$REPO_DIR" all CXXFLAGS="$COVERAGE_CXXFLAGS" LDFLAGS="$COVERAGE_LDFLAGS"
+make -C "$REPO_DIR" all unit-tests CXXFLAGS="$COVERAGE_CXXFLAGS" LDFLAGS="$COVERAGE_LDFLAGS"
 "$REPO_DIR/tests/run_tests.sh"
 
 mkdir -p "$COVERAGE_DIR"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -565,8 +565,11 @@ EOF
 	"$REPO_DIR/exe/getConfidenceDensity" "$result" > "$conf_out" 2> "$tmp/conf.err"
 
 	grep -Fq "assignments with Gamma score found" "$tmp/gamma.err" || fail "getGammaDensity did not process gamma scores"
+	grep -Fq "[0.50,0.52[" "$gamma_out" || fail "getGammaDensity did not report expected 0.50 gamma bucket"
 	grep -Fq "[>=1]" "$gamma_out" || fail "getGammaDensity did not report the >=1 gamma bucket"
 	grep -Fq "assignments with confidence score found" "$tmp/conf.err" || fail "getConfidenceDensity did not process confidence scores"
+	grep -Fq "[0.80,0.82[" "$conf_out" || fail "getConfidenceDensity did not report expected 0.80 confidence bucket"
+	grep -Fq "[1]" "$conf_out" || fail "getConfidenceDensity did not report the exact confidence score 1 bucket"
 	grep -Fq "[4.00,4.02[" "$conf_out" && fail "getConfidenceDensity emitted an impossible interval"
 	grep -Fq "Interval" "$conf_out" || fail "getConfidenceDensity did not emit a density table"
 	pass "density helpers summarize synthetic CLARK scores"
@@ -595,13 +598,45 @@ read1,4,111
 read2,4,222
 EOF
 
-	"$REPO_DIR/exe/extractSeqs" 111 "$reads" "$results" "$out_prefix" 0 0 > "$tmp/stdout" 2> "$tmp/stderr"
+	"$REPO_DIR/exe/extractSeqs" 111 "$reads" "$results" "$out_prefix" > "$tmp/stdout" 2> "$tmp/stderr"
 
 	grep -Fq "@read1" "$out_prefix.fq" || fail "extractSeqs did not extract the matching read"
 	if grep -Fq "@read2" "$out_prefix.fq"; then
 		fail "extractSeqs extracted a read assigned to a different taxid"
 	fi
 	pass "extractSeqs extracts matching FASTQ records"
+}
+
+test_extract_seqs_long_report_thresholds() {
+	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-extract-long-test.XXXXXX")"
+	trap 'rm -rf "$tmp"' RETURN
+
+	reads="$tmp/reads.fa"
+	results="$tmp/results.csv"
+	out_prefix="$tmp/extracted"
+	cat > "$reads" <<'EOF'
+>read1 description
+ACGT
+>read2
+TGCA
+>read3
+CCCC
+EOF
+	cat > "$results" <<'EOF'
+Object_ID,Length,Gamma,1st_assignment,score1,2nd_assignment,score2,confidence
+read1,4,0.50,111,9,222,3,0.80
+read2,4,0.01,111,9,222,3,0.90
+read3,4,0.50,222,9,111,3,0.90
+EOF
+
+	"$REPO_DIR/exe/extractSeqs" 111 "$reads" "$results" "$out_prefix" 0.03 0.75 > "$tmp/stdout" 2> "$tmp/stderr"
+
+	grep -Fq ">read1 description" "$out_prefix.fa" || fail "extractSeqs did not keep FASTA header for passing long-report assignment"
+	grep -Fq "ACGT" "$out_prefix.fa" || fail "extractSeqs did not keep FASTA sequence for passing long-report assignment"
+	if grep -Fq ">read2" "$out_prefix.fa" || grep -Fq ">read3" "$out_prefix.fa"; then
+		fail "extractSeqs kept filtered or wrong-taxid FASTA records"
+	fi
+	pass "extractSeqs applies gamma/confidence thresholds for long reports"
 }
 
 test_get_abundance_smoke() {
@@ -626,6 +661,35 @@ EOF
 	grep -Fq "111,111,2," "$out" || fail "getAbundance did not count assigned reads"
 	grep -Fq "UNKNOWN,UNKNOWN,1," "$out" || fail "getAbundance did not count unassigned reads"
 	pass "getAbundance summarizes a tiny assignment file"
+}
+
+test_get_abundance_filters_extended_scores() {
+	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-abundance-filter-test.XXXXXX")"
+	trap 'rm -rf "$tmp"' RETURN
+
+	results="$tmp/results.csv"
+	out="$tmp/abundance.csv"
+	cat > "$results" <<'EOF'
+Object_ID,Length,Gamma,1st_assignment,score1,2nd_assignment,score2,confidence
+read1,100,0.50,111,9,222,3,0.80
+read2,100,0.01,222,9,111,3,0.90
+read3,100,0.50,333,9,111,3,0.60
+read4,100,0.50,NA,0,NA,0,1.00
+EOF
+
+	(
+		cd "$tmp"
+		"$REPO_DIR/exe/getAbundance" -F "$results" -c 0.75 -g 0.03 > "$out"
+	)
+
+	grep -Fq "111,111,1,25,100" "$out" || fail "getAbundance did not keep the high-confidence assignment"
+	grep -Fq "UNKNOWN,UNKNOWN,3,75,-" "$out" || fail "getAbundance did not move filtered assignments to UNKNOWN"
+	if "$REPO_DIR/exe/getAbundance" -c 0.80 > "$tmp/no_file.out" 2> "$tmp/no_file.err"; then
+		fail "getAbundance accepted missing -F results"
+	fi
+	grep -Fq "Please provide one (or several) CLARK output file" "$tmp/no_file.err" ||
+		fail "getAbundance did not explain missing -F results"
+	pass "getAbundance filters extended scores and validates required input"
 }
 
 test_make_summary_tables_smoke() {
@@ -656,27 +720,57 @@ EOF
 	pass "makeSummaryTables writes summary tables for tiny reports"
 }
 
+test_make_summary_tables_all_unknown() {
+	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-summary-empty-test.XXXXXX")"
+	trap 'rm -rf "$tmp"' RETURN
+
+	report="$tmp/all_unknown.csv"
+	cat > "$report" <<'EOF'
+Name,TaxID,Count,Proportion_All(%),Proportion_Classified(%)
+UNKNOWN,UNKNOWN,4,100,-
+EOF
+
+	(
+		cd "$tmp"
+		"$REPO_DIR/exe/makeSummaryTables" 3 0 "$report" > stdout 2> stderr
+	)
+
+	grep -Fq "all_unknown,4,0," "$tmp/TableSummary_per_Report.csv" || fail "makeSummaryTables did not summarize an all-UNKNOWN report"
+	grep -Fq "#TotalReads,4," "$tmp/TableSummary_HitCount.csv" || fail "makeSummaryTables did not write total reads for all-UNKNOWN report"
+	grep -Fq "#TotalReadsMapped,0," "$tmp/TableSummary_HitCount.csv" || fail "makeSummaryTables did not write mapped reads for all-UNKNOWN report"
+	pass "makeSummaryTables handles reports with no classified taxa"
+}
+
 test_target_specific_kmers_stat_smoke() {
 	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-kmer-stat-test.XXXXXX")"
 	trap 'rm -rf "$tmp"' RETURN
 
+	fake_home="$tmp/home"
 	settings="$tmp/settings"
 	targets="$tmp/targets.txt"
 	dbdir="$tmp/db"
-	label_file="$dbdir/db_central_k3_t2_s1610612741_m0.tsk.lb"
-	mkdir -p "$dbdir"
+	label_file="$dbdir/db_central_k2_t2_s1610612741_m0.tsk.lb"
+	mkdir -p "$dbdir" "$fake_home/exe"
+	ln -s "$REPO_DIR/exe/getTargetSpecificKmersStat" "$fake_home/exe/getTargetSpecificKmersStat"
 	printf '%s\t%s\n%s\t%s\n' "$tmp/refA.fa" "111" "$tmp/refB.fa" "222" > "$targets"
 	printf -- '-T %s\n-D %s\n' "$targets" "$dbdir" > "$settings"
+	cp "$settings" "$fake_home/.settings"
 	printf '\000\000\001\000\001\000' > "$label_file"
 
 	(
 		cd "$tmp"
-		"$REPO_DIR/exe/getTargetSpecificKmersStat" "$settings" 3 0 > stdout 2> stderr
+		"$REPO_DIR/exe/getTargetSpecificKmersStat" "$settings" 2 0 > stdout 2> stderr
 	)
 
 	grep -Fq "111,1," "$tmp/targets.distribution.csv" || fail "getTargetSpecificKmersStat did not count target 111"
 	grep -Fq "222,2," "$tmp/targets.distribution.csv" || fail "getTargetSpecificKmersStat did not count target 222"
-	pass "getTargetSpecificKmersStat counts labels in a tiny database"
+	rm "$tmp/targets.distribution.csv"
+	(
+		cd "$tmp"
+		CLARK_HOME="$fake_home" "$REPO_DIR/scripts/getTargetsKmers_distribution.sh" 2 > stdout.script 2> stderr.script
+	)
+	grep -Fq "111,1," "$tmp/targets.distribution.csv" || fail "getTargetsKmers_distribution.sh did not default min frequency to 0"
+	pass "getTargetSpecificKmersStat counts labels in a tiny boundary-k database"
 }
 
 test_clark_l_label_bug_regression() {
@@ -731,8 +825,11 @@ test_exe_seq_smoke
 test_dscript_maker_smoke
 test_density_helpers_smoke
 test_extract_seqs_smoke
+test_extract_seqs_long_report_thresholds
 test_get_abundance_smoke
+test_get_abundance_filters_extended_scores
 test_make_summary_tables_smoke
+test_make_summary_tables_all_unknown
 test_target_specific_kmers_stat_smoke
 test_clark_l_label_bug_regression
 test_ncbi_urls

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -79,6 +79,32 @@ test_version_binaries() {
 	pass "CLARK variant version executables run"
 }
 
+test_kso_requires_spectrum_mode() {
+	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-kso-test.XXXXXX")"
+	trap 'rm -rf "$tmp"' RETURN
+
+	targets="$tmp/targets.txt"
+	db="$tmp/db"
+	objects="$tmp/objects.fa"
+	result="$tmp/result.csv"
+	output="$tmp/output.txt"
+
+	printf 'target.fa 12345\n' > "$targets"
+	printf '' > "$db"
+	printf '>read1\nACGT\n' > "$objects"
+
+	for binary in CLARK CLARK-l CLARK-S; do
+		for args in "--kso -m 0" "-m 0 --kso"; do
+			if "$REPO_DIR/exe/$binary" $args -T "$targets" -D "$db" -O "$objects" -R "$result" > "$output" 2>&1; then
+				fail "$binary accepted --kso outside spectrum mode with args: $args"
+			fi
+			grep -Fq "option '--kso' is only for the spectrum mode" "$output" ||
+				fail "$binary did not report --kso spectrum-mode validation for args: $args"
+		done
+	done
+	pass "--kso requires spectrum mode regardless of argument order"
+}
+
 create_fake_exe() {
 	local dir="$1"
 	mkdir -p "$dir"
@@ -678,6 +704,7 @@ test_shell_syntax
 test_no_root_shell_scripts
 test_required_executables
 test_version_binaries
+test_kso_requires_spectrum_mode
 test_classify_wrapper_quotes_paths
 test_classify_wrapper_gzip
 test_classify_wrapper_paired_light_variant

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -72,7 +72,7 @@ test_version_binaries() {
 	for binary in CLARK CLARK-l CLARK-S; do
 		version="$("$REPO_DIR/exe/$binary" --version)"
 		case "$version" in
-			*"Version: 1.4.2.0-a"*) ;;
+			*"Version: 1.4.3.0-a"*) ;;
 			*) fail "unexpected version output from $binary: $version" ;;
 		esac
 	done

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -79,6 +79,14 @@ test_version_binaries() {
 	pass "CLARK variant version executables run"
 }
 
+test_file_hash_unit_binary() {
+	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-file-hash-unit-test.XXXXXX")"
+	trap 'rm -rf "$tmp"' RETURN
+
+	[ -x "$REPO_DIR/exe/unit_file_hash_tests" ] || fail "missing executable exe/unit_file_hash_tests"
+	"$REPO_DIR/exe/unit_file_hash_tests" "$tmp"
+}
+
 test_kso_requires_spectrum_mode() {
 	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-kso-test.XXXXXX")"
 	trap 'rm -rf "$tmp"' RETURN
@@ -704,6 +712,7 @@ test_shell_syntax
 test_no_root_shell_scripts
 test_required_executables
 test_version_binaries
+test_file_hash_unit_binary
 test_kso_requires_spectrum_mode
 test_classify_wrapper_quotes_paths
 test_classify_wrapper_gzip

--- a/tests/unit_file_hash_tests.cc
+++ b/tests/unit_file_hash_tests.cc
@@ -1,0 +1,221 @@
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace std;
+
+#include "src/file.hh"
+#include "src/HashTop.hh"
+
+static int failures = 0;
+
+static void expectTrue(const bool condition, const std::string& message)
+{
+	if (!condition)
+	{
+		std::cerr << "FAIL: " << message << std::endl;
+		failures++;
+	}
+}
+
+static void expectString(const std::string& actual, const std::string& expected, const std::string& message)
+{
+	if (actual != expected)
+	{
+		std::cerr << "FAIL: " << message << " expected <" << expected << "> got <" << actual << ">" << std::endl;
+		failures++;
+	}
+}
+
+static void expectITYPE(const ITYPE actual, const ITYPE expected, const std::string& message)
+{
+	if (actual != expected)
+	{
+		std::cerr << "FAIL: " << message << " expected <" << expected << "> got <" << actual << ">" << std::endl;
+		failures++;
+	}
+}
+
+static std::string joinPath(const std::string& dir, const std::string& name)
+{
+	if (!dir.empty() && dir[dir.size() - 1] == '/')
+	{
+		return dir + name;
+	}
+	return dir + "/" + name;
+}
+
+static void writeText(const std::string& path, const std::string& text)
+{
+	std::ofstream out(path.c_str(), std::ios::binary);
+	out << text;
+	out.close();
+}
+
+static std::string readText(const std::string& path)
+{
+	std::ifstream in(path.c_str(), std::ios::binary);
+	std::ostringstream buffer;
+	buffer << in.rdbuf();
+	return buffer.str();
+}
+
+static void testStringElementParsing()
+{
+	std::vector<std::string> elements;
+	getElementsFromLine(" alpha,beta\tgamma  delta\r\n", 3, elements);
+	expectITYPE((ITYPE) elements.size(), 3, "comma/space parser returns max requested elements");
+	expectString(elements[0], "alpha", "first comma-separated element");
+	expectString(elements[1], "beta", "second comma-separated element");
+	expectString(elements[2], "gamma", "third comma-separated element");
+
+	std::vector<char> seps;
+	seps.push_back('>');
+	seps.push_back('/');
+	seps.push_back(' ');
+	seps.push_back('\t');
+	getElementsFromLine(">read1/2 comment", seps, elements);
+	expectITYPE((ITYPE) elements.size(), 3, "custom separator parser extracts all tokens");
+	expectString(elements[0], "read1", "custom parser read id");
+	expectString(elements[1], "2", "custom parser mate number");
+	expectString(elements[2], "comment", "custom parser trailing token");
+}
+
+static void testCharElementParsing()
+{
+	char line[] = "\t123  456\n789";
+	char* ptr = line;
+	std::vector<std::string> elements;
+	getElementsFromLine(ptr, std::strlen(ptr), 2, elements);
+	expectITYPE((ITYPE) elements.size(), 2, "char parser honors max elements");
+	expectString(elements[0], "123", "char parser first token");
+	expectString(elements[1], "456", "char parser second token");
+}
+
+static void testFileReaders(const std::string& tmpDir)
+{
+	const std::string path = joinPath(tmpDir, "readers.txt");
+	writeText(path, "first line\n  second\t42\n1234567890123 17\nACGT 29\n");
+
+	FILE* fd = fopen(path.c_str(), "r");
+	std::string line;
+	expectTrue(getLineFromFile(fd, line), "getLineFromFile reads first line");
+	expectString(line, "first line", "getLineFromFile strips newline");
+	expectTrue(getFirstElementInLineFromFile(fd, line), "getFirstElementInLineFromFile reads token");
+	expectString(line, "second", "getFirstElementInLineFromFile returns first token");
+
+	uint64_t kIndex = 0;
+	ITYPE index = 0;
+	expectTrue(getFirstAndSecondElementInLine(fd, kIndex, index), "numeric pair reader succeeds");
+	expectTrue(kIndex == 1234567890123ULL, "numeric pair reader parses first value");
+	expectITYPE(index, 17, "numeric pair reader parses second value");
+
+	ITYPE freq = 0;
+	expectTrue(getFirstAndSecondElementInLine(fd, line, freq), "string/frequency reader succeeds");
+	expectString(line, "ACGT", "string/frequency reader parses first token");
+	expectITYPE(freq, 29, "string/frequency reader parses frequency");
+	expectTrue(!getLineFromFile(fd, line), "getLineFromFile reports EOF");
+	expectString(line, "", "getLineFromFile clears line at EOF");
+	fclose(fd);
+}
+
+static void testFileLifecycleAndPairedMerge(const std::string& tmpDir)
+{
+	const std::string left = joinPath(tmpDir, "left.fastq");
+	const std::string right = joinPath(tmpDir, "right.fastq");
+	const std::string merged = joinPath(tmpDir, "merged.fa");
+	const std::string transient = joinPath(tmpDir, "transient.txt");
+
+	writeText(left, "@read1/1 comment\nACGT\n+\n!!!!\n@read2/1\nGG\n+\n!!\n");
+	writeText(right, "@read1/2 comment\nTTAA\n+\n!!!!\n@read2/2\nCC\n+\n!!\n");
+	mergePairedFiles(left.c_str(), right.c_str(), merged.c_str());
+	expectString(readText(merged), ">read1\nACGTNNNNTTAA\n>read2\nGGNNNNCC\n", "mergePairedFiles concatenates paired FASTQ reads");
+
+	writeText(transient, "temporary\n");
+	expectTrue(validFile(transient.c_str()), "validFile accepts readable files");
+	deleteFile(transient.c_str());
+	expectTrue(!validFile(transient.c_str()), "deleteFile removes readable files");
+	deleteFile(NULL);
+}
+
+static void testHashTopCounting()
+{
+	HashTop top;
+	ITYPE label = 99;
+	ITYPE count = 99;
+
+	top.getBest(label, count);
+	expectITYPE(label, 0, "empty HashTop best label is zero");
+	expectITYPE(count, 0, "empty HashTop best count is zero");
+	top.getSecondBest(label, count);
+	expectITYPE(label, 0, "empty HashTop second-best label is zero");
+	expectITYPE(count, 0, "empty HashTop second-best count is zero");
+	top.getTotal(count);
+	expectITYPE(count, 0, "empty HashTop total is zero");
+
+	top.insert(3);
+	top.insert(3);
+	top.insert(5);
+	top.insert(7, 4);
+	top.insert(5, 5);
+
+	top.getBest(label, count);
+	expectITYPE(label, 5, "HashTop best label follows highest count");
+	expectITYPE(count, 6, "HashTop best count combines weighted and unweighted inserts");
+	top.getSecondBest(label, count);
+	expectITYPE(label, 7, "HashTop second-best label excludes the best label");
+	expectITYPE(count, 4, "HashTop second-best count is tracked");
+	top.getTotal(count);
+	expectITYPE(count, 12, "HashTop total includes weighted inserts");
+
+	std::string scores;
+	top.getScoresLine(8, scores);
+	expectString(scores, ",0,0,0,2,0,6,0,4", "HashTop scores line reports counts for active token");
+
+	top.next();
+	top.getBest(label, count);
+	expectITYPE(label, 0, "HashTop next clears best label");
+	expectITYPE(count, 0, "HashTop next clears best count");
+	top.getTotal(count);
+	expectITYPE(count, 0, "HashTop next clears total");
+	top.getScoresLine(8, scores);
+	expectString(scores, ",0,0,0,0,0,0,0,0", "HashTop next hides stale table values");
+
+	top.insert(2);
+	top.insert(4);
+	top.getBest(label, count);
+	expectITYPE(label, 2, "HashTop keeps first label as best on ties");
+	expectITYPE(count, 1, "HashTop tie count remains one");
+	top.getSecondBest(label, count);
+	expectITYPE(label, 4, "HashTop second-best reports tied non-best label");
+	expectITYPE(count, 1, "HashTop second-best tied count remains one");
+}
+
+int main(int argc, char** argv)
+{
+	if (argc != 2)
+	{
+		std::cerr << "Usage: " << argv[0] << " <temporary-directory>" << std::endl;
+		return 2;
+	}
+
+	const std::string tmpDir(argv[1]);
+	testStringElementParsing();
+	testCharElementParsing();
+	testFileReaders(tmpDir);
+	testFileLifecycleAndPairedMerge(tmpDir);
+	testHashTopCounting();
+
+	if (failures != 0)
+	{
+		std::cerr << failures << " unit test failure(s)" << std::endl;
+		return 1;
+	}
+	std::cout << "PASS: file.cc/file.hh/HashTop.hh unit tests" << std::endl;
+	return 0;
+}

--- a/tests/unit_file_hash_tests.cc
+++ b/tests/unit_file_hash_tests.cc
@@ -7,10 +7,8 @@
 #include <string>
 #include <vector>
 
-using namespace std;
-
-#include "src/file.hh"
 #include "src/HashTop.hh"
+#include "src/file.hh"
 
 static int failures = 0;
 


### PR DESCRIPTION
## WHAT

Increased reliability, maintainability, and test coverage improvements.

## WHY

This release strengthens user-facing behavior for genomics/metagenomics researchers while preserving CLARK’s core classification behavior and performance-sensitive execution paths.

## HOW

- Simplified repeated CLARK classifier dispatch logic in `src/main.cc`.
- Fixed `--kso` validation so it is rejected outside spectrum mode regardless of argument order.
- Made `HashTop.hh` self-contained by qualifying `std::string`.
- Added unit coverage for `file.cc`, `file.hh`, and `HashTop.hh`.
- Added regression coverage for major user-facing analysis tools:
  - abundance estimation
  - confidence/gamma density helpers
  - summary table generation
  - target-specific k-mer distribution
  - sequence extraction
- Hardened edge cases for missing inputs, all-UNKNOWN reports, short vs extended CLARK reports, and documented k-mer boundary values.
- Updated release metadata for v1.4.3.0-a in `CHANGELOG`, `README.md`, `README_FULL.md`, and `src/parameters*`.

## TESTS

Passed locally:

- `make test`
- `make coverage`
  - Line coverage: `22.63%`
  - Required minimum: `20.00%`
- `make clean`
- `make all unit-tests`
- `exe/CLARK --version`
- `exe/CLARK-l --version`
- `exe/CLARK-S --version`

All CLARK binaries report:

## SECURITY CONCERNS
None