### PR TITLE
v1.4.4.0: Improved database download, code improvement and bugfixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+06/21/2026  Version 1.4.4.0-a:
+		Improved RefSeq database setup for large downloads, especially bacteria.
+		RefSeq downloads now use parallel resumable transfers by default and support filters for smaller exploratory databases.
+		Hardened download correctness with NCBI URL validation, retries, gzip validation, partial-file cleanup, and aggregate progress reporting.
+		Used RefSeq assembly-summary provenance to avoid large global accession-map lookups when taxids are already available.
+		Added regression tests for malformed URLs, transient parallel failures, progress reporting, and resumable downloads.
+		Planned follow-up: replace the shell download engine with a Python 3 standard-library downloader with manifest state, checksum validation, and optional rsync acceleration.
 06/21/2026  Version 1.4.3.0-a:
 		Simplified CLARK classifier dispatch and tightened --kso mode validation.
 		Added unit and regression tests for file helpers, HashTop, and user-facing analysis tools.

--- a/README.md
+++ b/README.md
@@ -185,12 +185,12 @@ Scripts provided for metagenomic classification:
    - Bacteria, viruses, and human: `scripts/set_targets.sh <DIR_DB/> bacteria viruses human`
    - Bacteria and custom: `scripts/set_targets.sh <DIR_DB/> bacteria custom`
 
-For faster RefSeq setup, especially for bacteria, use parallel and resumable
-downloads and optionally restrict RefSeq assemblies to representative or
-reference genomes:
+RefSeq downloads use 8 parallel workers and resume mode by default. To build a
+smaller bacteria database for exploratory work, restrict RefSeq assemblies to
+representative or reference genomes:
 
 ```sh
-scripts/set_targets.sh <DIR_DB/> bacteria --download-threads 8 --resume-downloads --refseq-category representative
+scripts/set_targets.sh <DIR_DB/> bacteria --refseq-category representative
 ```
 
 By default CLARK keeps the historical behavior: all latest complete RefSeq

--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ CLARK is distributed under the GNU General Public License (GPL) v3. It is free s
 
 ## Releases
 
+### Version 1.4.4 (June 21, 2026)
+- Improved large RefSeq database setup, especially for bacteria, with parallel resumable downloads by default.
+- Added RefSeq category and assembly-level filters for smaller exploratory databases.
+- Hardened download reliability with NCBI URL validation, retries, gzip validation, partial-file cleanup, and aggregate progress reporting.
+- Used RefSeq assembly-summary provenance to avoid large accession-map lookups when taxids are already available.
+- Added regression tests for malformed URLs, transient parallel failures, progress reporting, and resumable downloads.
+
 ### Version 1.4.3 (June 21, 2026)
 - Simplified CLARK classifier dispatch and made `--kso` validation order-independent.
 - Added focused unit/regression tests for file helpers, `HashTop`, and user-facing analysis tools.

--- a/README.md
+++ b/README.md
@@ -185,6 +185,19 @@ Scripts provided for metagenomic classification:
    - Bacteria, viruses, and human: `scripts/set_targets.sh <DIR_DB/> bacteria viruses human`
    - Bacteria and custom: `scripts/set_targets.sh <DIR_DB/> bacteria custom`
 
+For faster RefSeq setup, especially for bacteria, use parallel and resumable
+downloads and optionally restrict RefSeq assemblies to representative or
+reference genomes:
+
+```sh
+scripts/set_targets.sh <DIR_DB/> bacteria --download-threads 8 --resume-downloads --refseq-category representative
+```
+
+By default CLARK keeps the historical behavior: all latest complete RefSeq
+assemblies for the selected database are downloaded. For standard RefSeq
+libraries with assembly-summary taxids, CLARK now uses that provenance directly
+and avoids the large global accession-map lookup when it is not needed.
+
 ### Running the Classification
 
 Example commands:

--- a/README_FULL.md
+++ b/README_FULL.md
@@ -919,15 +919,16 @@ the selected database(s) and also data of the taxonomy tree, from NCBI.
 Once the sequences are found or downloaded in the directory, the script will build 
 the targets for a given taxonomy rank. 
 
-Large RefSeq downloads, especially bacteria, can take a long time. To speed up
-the download step, `scripts/set_targets.sh` accepts RefSeq download options:
+Large RefSeq downloads, especially bacteria, can take a long time. RefSeq
+downloads use 8 parallel workers and resume mode by default. These defaults can
+be overridden if needed:
 ```
-$ scripts/set_targets.sh <DIR_DB/> bacteria --download-threads 8 --resume-downloads
+$ scripts/set_targets.sh <DIR_DB/> bacteria --download-threads 4
 ```
 To build a smaller bacteria database for exploratory work, restrict RefSeq
 assembly summaries to representative or reference genomes:
 ```
-$ scripts/set_targets.sh <DIR_DB/> bacteria --download-threads 8 --resume-downloads --refseq-category representative
+$ scripts/set_targets.sh <DIR_DB/> bacteria --refseq-category representative
 ```
 The default remains all latest complete RefSeq assemblies. For standard RefSeq
 libraries where NCBI assembly summaries provide taxids, CLARK uses that

--- a/README_FULL.md
+++ b/README_FULL.md
@@ -1296,6 +1296,8 @@ In the default or express mode, the results format is the following for each lin
 
 ## VERSIONS
 
+Version 1.4.4.0-a	June 21, 2026.
+
 Version 1.4.3.0-a	June 21, 2026.
 
 Version 1.4.2.0-a	June 21, 2026.

--- a/README_FULL.md
+++ b/README_FULL.md
@@ -919,6 +919,21 @@ the selected database(s) and also data of the taxonomy tree, from NCBI.
 Once the sequences are found or downloaded in the directory, the script will build 
 the targets for a given taxonomy rank. 
 
+Large RefSeq downloads, especially bacteria, can take a long time. To speed up
+the download step, `scripts/set_targets.sh` accepts RefSeq download options:
+```
+$ scripts/set_targets.sh <DIR_DB/> bacteria --download-threads 8 --resume-downloads
+```
+To build a smaller bacteria database for exploratory work, restrict RefSeq
+assembly summaries to representative or reference genomes:
+```
+$ scripts/set_targets.sh <DIR_DB/> bacteria --download-threads 8 --resume-downloads --refseq-category representative
+```
+The default remains all latest complete RefSeq assemblies. For standard RefSeq
+libraries where NCBI assembly summaries provide taxids, CLARK uses that
+provenance directly and avoids downloading/processing the large global
+accession maps when they are not needed.
+
 The default taxonomy rank is species. To use a different taxonomy rank, for example, 
 genus, the command line is (from the example selecting bacteria, viruses and human):
 ```

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -31,17 +31,18 @@ can be very large.
 scripts/set_targets.sh /path/to/clark-db bacteria viruses --species
 ```
 
-For faster bacteria setup, use parallel resumable downloads:
+RefSeq downloads use 8 parallel workers and resume mode by default. To override
+the worker count:
 
 ```sh
-scripts/set_targets.sh /path/to/clark-db bacteria --download-threads 8 --resume-downloads --species
+scripts/set_targets.sh /path/to/clark-db bacteria --download-threads 4 --species
 ```
 
 For exploratory runs where a smaller database is acceptable, use RefSeq
 representative genomes:
 
 ```sh
-scripts/set_targets.sh /path/to/clark-db bacteria --download-threads 8 --resume-downloads --refseq-category representative --species
+scripts/set_targets.sh /path/to/clark-db bacteria --refseq-category representative --species
 ```
 
 This writes the target configuration into CLARK's local `.settings` file and

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -31,6 +31,19 @@ can be very large.
 scripts/set_targets.sh /path/to/clark-db bacteria viruses --species
 ```
 
+For faster bacteria setup, use parallel resumable downloads:
+
+```sh
+scripts/set_targets.sh /path/to/clark-db bacteria --download-threads 8 --resume-downloads --species
+```
+
+For exploratory runs where a smaller database is acceptable, use RefSeq
+representative genomes:
+
+```sh
+scripts/set_targets.sh /path/to/clark-db bacteria --download-threads 8 --resume-downloads --refseq-category representative --species
+```
+
 This writes the target configuration into CLARK's local `.settings` file and
 stores database-specific files under `/path/to/clark-db`. CLARK records this
 database directory as an absolute path so later classification and maintenance

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,7 +23,23 @@ Before downloading large RefSeq datasets, you can inspect the planned work:
 scripts/download_RefSeqDB.sh --dry-run /path/to/clark-db bacteria
 ```
 
+For large bacteria databases, use parallel and resumable downloads from the
+user-facing setup script:
+
+```sh
+scripts/set_targets.sh /path/to/clark-db bacteria --download-threads 8 --resume-downloads
+```
+
+For faster exploratory databases, restrict RefSeq assembly summaries to
+representative or reference genomes:
+
+```sh
+scripts/set_targets.sh /path/to/clark-db bacteria --download-threads 8 --resume-downloads --refseq-category representative
+```
+
 The downloader writes `.<database>.download_manifest.tsv` and
 `.<database>.provenance.tsv` in the database directory. These files record the
 planned or completed URLs, source accessions, and RefSeq source dates when they
-are available from NCBI assembly summaries.
+are available from NCBI assembly summaries. Standard RefSeq libraries with
+assembly-summary taxids can use this provenance directly, avoiding the large
+global accession-map lookup when it is not needed.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,18 +23,18 @@ Before downloading large RefSeq datasets, you can inspect the planned work:
 scripts/download_RefSeqDB.sh --dry-run /path/to/clark-db bacteria
 ```
 
-For large bacteria databases, use parallel and resumable downloads from the
-user-facing setup script:
+RefSeq downloads use 8 parallel workers and resume mode by default. To override
+the worker count, pass `--download-threads` to the user-facing setup script:
 
 ```sh
-scripts/set_targets.sh /path/to/clark-db bacteria --download-threads 8 --resume-downloads
+scripts/set_targets.sh /path/to/clark-db bacteria --download-threads 4
 ```
 
 For faster exploratory databases, restrict RefSeq assembly summaries to
 representative or reference genomes:
 
 ```sh
-scripts/set_targets.sh /path/to/clark-db bacteria --download-threads 8 --resume-downloads --refseq-category representative
+scripts/set_targets.sh /path/to/clark-db bacteria --refseq-category representative
 ```
 
 The downloader writes `.<database>.download_manifest.tsv` and

--- a/scripts/download_RefSeqDB.sh
+++ b/scripts/download_RefSeqDB.sh
@@ -273,7 +273,7 @@ download_assembly_source() {
 		-v assembly_level="$ASSEMBLY_LEVEL" \
 		-v download_list="$DOWNLOAD_LIST" '
 			BEGIN { OFS = "\t" }
-			$0 !~ /^#/ && $11 == "latest" && $20 != "" {
+			$0 !~ /^#/ && $11 == "latest" && $20 != "" && $20 != "na" {
 				if (assembly_level != "all" && $12 != assembly_level) {
 					next
 				}
@@ -283,8 +283,13 @@ download_assembly_source() {
 				if (category == "reference" && $5 != "reference genome") {
 					next
 				}
-				n = split($20, path_parts, "/")
-				url = $20 "/" path_parts[n] "_genomic.fna.gz"
+				ftp_path = $20
+				sub(/\/+$/, "", ftp_path)
+				n = split(ftp_path, path_parts, "/")
+				if (ftp_path == "" || path_parts[n] == "") {
+					next
+				}
+				url = ftp_path "/" path_parts[n] "_genomic.fna.gz"
 				print db, source, $1, $6, $7, $15, $12, $11, url >> provenance
 				print source, url >> download_list
 			}
@@ -333,7 +338,30 @@ write_sequence_marker() {
 	find "$(pwd)" -name "$(sequence_pattern)" > "$MARKER"
 }
 
+validate_download_list() {
+	awk -F '\t' '
+		NF < 2 || $1 == "" || $2 == "" {
+			print "Malformed RefSeq download entry: missing source or URL" > "/dev/stderr"
+			exit 1
+		}
+		{
+			url = $2
+			file_name = url
+			sub(/^.*\//, "", file_name)
+			if (file_name == "" || file_name == "_genomic.fna.gz" || file_name == ".genomic.fna.gz") {
+				print "Malformed RefSeq download URL: " url > "/dev/stderr"
+				exit 1
+			}
+			if (url ~ /\/\/_genomic\.fna\.gz$/ || url !~ /\.fna\.gz$/) {
+				print "Malformed RefSeq download URL: " url > "/dev/stderr"
+				exit 1
+			}
+		}
+	' "$DOWNLOAD_LIST" || die "generated malformed RefSeq download URL(s); aborting before download"
+}
+
 download_url_list() {
+	validate_download_list
 	total=$(wc -l < "$DOWNLOAD_LIST" | tr -d ' ')
 	echo "Selected $total $DB RefSeq genome(s) using assembly_level=$ASSEMBLY_LEVEL and refseq_category=$REFSEQ_CATEGORY."
 

--- a/scripts/download_RefSeqDB.sh
+++ b/scripts/download_RefSeqDB.sh
@@ -459,7 +459,7 @@ download_url_list() {
 		if [ "$job_count" -ge "$THREADS" ]; then
 			wait || die "failed to download one or more RefSeq genomes"
 			completed=$((completed + job_count))
-			if [ "$completed" -ge "$next_report" ] || [ "$completed" -ge "$total" ]; then
+			if [ -t 1 ] || [ "$completed" -ge "$next_report" ] || [ "$completed" -ge "$total" ]; then
 				report_download_progress "$completed" "$total"
 				while [ "$next_report" -le "$completed" ]; do
 					next_report=$((next_report + progress_step))

--- a/scripts/download_RefSeqDB.sh
+++ b/scripts/download_RefSeqDB.sh
@@ -30,8 +30,8 @@ Usage: $0 [options] <Directory for the sequences> <Database: bacteria, viruses, 
 
 Options:
   --dry-run                         Plan downloads without fetching sequence files.
-  --threads <N>                     Download up to N sequence files at a time (default: 1).
-  --resume                          Keep existing sequence files and resume partial downloads.
+  --threads <N>                     Download up to N sequence files at a time (default: 8).
+  --resume                          Keep existing sequence files and resume partial downloads (default: on).
   --refseq-category <all|representative|reference>
                                     Filter RefSeq assembly summaries by refseq_category (default: all).
   --assembly-level <level|all>      Filter RefSeq assembly summaries by assembly_level (default: Complete Genome).
@@ -44,8 +44,8 @@ die() {
 }
 
 DRY_RUN=${CLARK_REFSEQ_DRY_RUN:-0}
-THREADS=${CLARK_REFSEQ_THREADS:-1}
-RESUME=${CLARK_REFSEQ_RESUME:-0}
+THREADS=${CLARK_REFSEQ_THREADS:-8}
+RESUME=${CLARK_REFSEQ_RESUME:-1}
 REFSEQ_CATEGORY=${CLARK_REFSEQ_CATEGORY:-all}
 ASSEMBLY_LEVEL=${CLARK_REFSEQ_ASSEMBLY_LEVEL:-Complete Genome}
 
@@ -206,9 +206,13 @@ fetch_to_file() {
 	source="$3"
 
 	if command -v wget >/dev/null 2>&1; then
-		wget -O "$output" "$url"
+		if ! wget -q -O "$output" "$url"; then
+			die "failed to download $url"
+		fi
 	elif command -v curl >/dev/null 2>&1; then
-		curl -fL -o "$output" "$url"
+		if ! curl -fsSL --retry 3 -o "$output" "$url"; then
+			die "failed to download $url"
+		fi
 	else
 		die "neither wget nor curl is available"
 	fi
@@ -239,21 +243,36 @@ fetch_url_to_status() {
 
 	if command -v wget >/dev/null 2>&1; then
 		if [ "$RESUME" = "1" ]; then
-			wget -c -O "$partial" "$url"
+			if ! wget -q -c -O "$partial" "$url"; then
+				echo "Failed to download $url" >&2
+				return 1
+			fi
 		else
-			wget -O "$partial" "$url"
+			if ! wget -q -O "$partial" "$url"; then
+				echo "Failed to download $url" >&2
+				return 1
+			fi
 		fi
 	elif command -v curl >/dev/null 2>&1; then
 		if [ "$RESUME" = "1" ]; then
-			curl -fL -C - -o "$partial" "$url"
+			if ! curl -fsSL --retry 3 -C - -o "$partial" "$url"; then
+				echo "Failed to download $url" >&2
+				return 1
+			fi
 		else
-			curl -fL -o "$partial" "$url"
+			if ! curl -fsSL --retry 3 -o "$partial" "$url"; then
+				echo "Failed to download $url" >&2
+				return 1
+			fi
 		fi
 	else
 		die "neither wget nor curl is available"
 	fi
 
-	[ -s "$partial" ] || return 1
+	if [ ! -s "$partial" ]; then
+		echo "Failed to download $url" >&2
+		return 1
+	fi
 	mv "$partial" "$output"
 	record_manifest_line "$status_file" "download" "$source" "$url" "$(pwd)/$output" "downloaded"
 }
@@ -360,6 +379,17 @@ validate_download_list() {
 	' "$DOWNLOAD_LIST" || die "generated malformed RefSeq download URL(s); aborting before download"
 }
 
+report_download_progress() {
+	completed="$1"
+	total="$2"
+	if [ "$total" -eq 0 ]; then
+		echo "RefSeq download progress: 0/0 files complete (100%)."
+		return 0
+	fi
+	percent=$((completed * 100 / total))
+	echo "RefSeq download progress: $completed/$total files complete ($percent%)."
+}
+
 download_url_list() {
 	validate_download_list
 	total=$(wc -l < "$DOWNLOAD_LIST" | tr -d ' ')
@@ -378,6 +408,11 @@ download_url_list() {
 	mkdir -p "$status_dir"
 	job_count=0
 	job_index=0
+	completed=0
+	progress_step=$((total / 20))
+	[ "$progress_step" -gt 0 ] || progress_step=1
+	next_report="$progress_step"
+	report_download_progress 0 "$total"
 	while IFS='	' read -r source genome_url || [ -n "$genome_url" ]; do
 		[ -n "$genome_url" ] || continue
 		job_index=$((job_index + 1))
@@ -385,10 +420,21 @@ download_url_list() {
 		job_count=$((job_count + 1))
 		if [ "$job_count" -ge "$THREADS" ]; then
 			wait || die "failed to download one or more RefSeq genomes"
+			completed=$((completed + job_count))
+			if [ "$completed" -ge "$next_report" ] || [ "$completed" -ge "$total" ]; then
+				report_download_progress "$completed" "$total"
+				while [ "$next_report" -le "$completed" ]; do
+					next_report=$((next_report + progress_step))
+				done
+			fi
 			job_count=0
 		fi
 	done < "$DOWNLOAD_LIST"
-	wait || die "failed to download one or more RefSeq genomes"
+	if [ "$job_count" -gt 0 ]; then
+		wait || die "failed to download one or more RefSeq genomes"
+		completed=$((completed + job_count))
+		report_download_progress "$completed" "$total"
+	fi
 
 	if [ -n "$(find "$status_dir" -type f -print -quit)" ]; then
 		cat "$status_dir"/*.tsv >> "$MANIFEST"

--- a/scripts/download_RefSeqDB.sh
+++ b/scripts/download_RefSeqDB.sh
@@ -46,6 +46,8 @@ die() {
 DRY_RUN=${CLARK_REFSEQ_DRY_RUN:-0}
 THREADS=${CLARK_REFSEQ_THREADS:-8}
 RESUME=${CLARK_REFSEQ_RESUME:-1}
+DOWNLOAD_ATTEMPTS=${CLARK_REFSEQ_DOWNLOAD_ATTEMPTS:-5}
+RETRY_DELAY=${CLARK_REFSEQ_RETRY_DELAY:-2}
 REFSEQ_CATEGORY=${CLARK_REFSEQ_CATEGORY:-all}
 ASSEMBLY_LEVEL=${CLARK_REFSEQ_ASSEMBLY_LEVEL:-Complete Genome}
 
@@ -92,6 +94,15 @@ case "$THREADS" in
 	''|*[!0-9]*) die "--threads must be a positive integer" ;;
 esac
 [ "$THREADS" -gt 0 ] || die "--threads must be a positive integer"
+
+case "$DOWNLOAD_ATTEMPTS" in
+	''|*[!0-9]*) die "CLARK_REFSEQ_DOWNLOAD_ATTEMPTS must be a positive integer" ;;
+esac
+[ "$DOWNLOAD_ATTEMPTS" -gt 0 ] || die "CLARK_REFSEQ_DOWNLOAD_ATTEMPTS must be a positive integer"
+
+case "$RETRY_DELAY" in
+	''|*[!0-9]*) die "CLARK_REFSEQ_RETRY_DELAY must be a non-negative integer" ;;
+esac
 
 case "$REFSEQ_CATEGORY" in
 	all|representative|reference) ;;
@@ -221,6 +232,32 @@ fetch_to_file() {
 	record_manifest "metadata" "$source" "$url" "$output" "downloaded"
 }
 
+valid_gzip_archive() {
+	[ -s "$1" ] || return 1
+	gzip -t "$1" >/dev/null 2>&1
+}
+
+run_sequence_download_once() {
+	url="$1"
+	partial="$2"
+
+	if command -v wget >/dev/null 2>&1; then
+		if [ "$RESUME" = "1" ] && [ -s "$partial" ]; then
+			wget -q -c -O "$partial" "$url"
+		else
+			wget -q -O "$partial" "$url"
+		fi
+	elif command -v curl >/dev/null 2>&1; then
+		if [ "$RESUME" = "1" ] && [ -s "$partial" ]; then
+			curl -fsSL --retry 3 -C - -o "$partial" "$url"
+		else
+			curl -fsSL --retry 3 -o "$partial" "$url"
+		fi
+	else
+		die "neither wget nor curl is available"
+	fi
+}
+
 fetch_url_to_status() {
 	url="$1"
 	source="$2"
@@ -228,8 +265,12 @@ fetch_url_to_status() {
 	output=${url##*/}
 
 	if [ -s "$output" ]; then
-		record_manifest_line "$status_file" "download" "$source" "$url" "$(pwd)/$output" "skipped-existing"
-		return 0
+		if ! valid_gzip_archive "$output"; then
+			rm -f "$output"
+		else
+			record_manifest_line "$status_file" "download" "$source" "$url" "$(pwd)/$output" "skipped-existing"
+			return 0
+		fi
 	fi
 	if [ "${output%.gz}" != "$output" ] && [ -s "${output%.gz}" ]; then
 		record_manifest_line "$status_file" "download" "$source" "$url" "$(pwd)/${output%.gz}" "skipped-existing"
@@ -241,40 +282,26 @@ fetch_url_to_status() {
 		rm -f "$partial"
 	fi
 
-	if command -v wget >/dev/null 2>&1; then
-		if [ "$RESUME" = "1" ]; then
-			if ! wget -q -c -O "$partial" "$url"; then
-				echo "Failed to download $url" >&2
-				return 1
-			fi
-		else
-			if ! wget -q -O "$partial" "$url"; then
-				echo "Failed to download $url" >&2
-				return 1
-			fi
+	attempt=1
+	while [ "$attempt" -le "$DOWNLOAD_ATTEMPTS" ]; do
+		if run_sequence_download_once "$url" "$partial"; then
+			:
 		fi
-	elif command -v curl >/dev/null 2>&1; then
-		if [ "$RESUME" = "1" ]; then
-			if ! curl -fsSL --retry 3 -C - -o "$partial" "$url"; then
-				echo "Failed to download $url" >&2
-				return 1
-			fi
-		else
-			if ! curl -fsSL --retry 3 -o "$partial" "$url"; then
-				echo "Failed to download $url" >&2
-				return 1
-			fi
+		if valid_gzip_archive "$partial"; then
+			mv "$partial" "$output"
+			record_manifest_line "$status_file" "download" "$source" "$url" "$(pwd)/$output" "downloaded"
+			return 0
 		fi
-	else
-		die "neither wget nor curl is available"
-	fi
+		rm -f "$partial"
+		if [ "$attempt" -lt "$DOWNLOAD_ATTEMPTS" ] && [ "$RETRY_DELAY" -gt 0 ]; then
+			sleep $((RETRY_DELAY * attempt))
+		fi
+		attempt=$((attempt + 1))
+	done
 
-	if [ ! -s "$partial" ]; then
-		echo "Failed to download $url" >&2
-		return 1
-	fi
-	mv "$partial" "$output"
-	record_manifest_line "$status_file" "download" "$source" "$url" "$(pwd)/$output" "downloaded"
+	echo "Failed to download $url after $DOWNLOAD_ATTEMPTS attempt(s)" >&2
+	rm -f "$partial"
+	return 1
 }
 
 download_assembly_source() {
@@ -383,11 +410,21 @@ report_download_progress() {
 	completed="$1"
 	total="$2"
 	if [ "$total" -eq 0 ]; then
-		echo "RefSeq download progress: 0/0 files complete (100%)."
+		message="RefSeq download progress: 0/0 files complete (100%)."
+		if [ -t 1 ]; then printf '\r%s\n' "$message"; else echo "$message"; fi
 		return 0
 	fi
 	percent=$((completed * 100 / total))
-	echo "RefSeq download progress: $completed/$total files complete ($percent%)."
+	message="RefSeq download progress: $completed/$total files complete ($percent%)."
+	if [ -t 1 ]; then
+		if [ "$completed" -ge "$total" ]; then
+			printf '\r%s\n' "$message"
+		else
+			printf '\r%s' "$message"
+		fi
+	else
+		echo "$message"
+	fi
 }
 
 download_url_list() {
@@ -409,8 +446,9 @@ download_url_list() {
 	job_count=0
 	job_index=0
 	completed=0
-	progress_step=$((total / 20))
+	progress_step=$((total / 100))
 	[ "$progress_step" -gt 0 ] || progress_step=1
+	[ "$progress_step" -le 100 ] || progress_step=100
 	next_report="$progress_step"
 	report_download_progress 0 "$total"
 	while IFS='	' read -r source genome_url || [ -n "$genome_url" ]; do
@@ -437,7 +475,7 @@ download_url_list() {
 	fi
 
 	if [ -n "$(find "$status_dir" -type f -print -quit)" ]; then
-		cat "$status_dir"/*.tsv >> "$MANIFEST"
+		find "$status_dir" -type f -name '*.tsv' -exec cat {} + >> "$MANIFEST"
 	fi
 	rm -rf "$status_dir"
 }

--- a/scripts/download_RefSeqDB.sh
+++ b/scripts/download_RefSeqDB.sh
@@ -47,6 +47,7 @@ DRY_RUN=${CLARK_REFSEQ_DRY_RUN:-0}
 THREADS=${CLARK_REFSEQ_THREADS:-8}
 RESUME=${CLARK_REFSEQ_RESUME:-1}
 DOWNLOAD_ATTEMPTS=${CLARK_REFSEQ_DOWNLOAD_ATTEMPTS:-5}
+FIRST_PASS_ATTEMPTS=${CLARK_REFSEQ_FIRST_PASS_ATTEMPTS:-3}
 RETRY_DELAY=${CLARK_REFSEQ_RETRY_DELAY:-2}
 REFSEQ_CATEGORY=${CLARK_REFSEQ_CATEGORY:-all}
 ASSEMBLY_LEVEL=${CLARK_REFSEQ_ASSEMBLY_LEVEL:-Complete Genome}
@@ -99,6 +100,11 @@ case "$DOWNLOAD_ATTEMPTS" in
 	''|*[!0-9]*) die "CLARK_REFSEQ_DOWNLOAD_ATTEMPTS must be a positive integer" ;;
 esac
 [ "$DOWNLOAD_ATTEMPTS" -gt 0 ] || die "CLARK_REFSEQ_DOWNLOAD_ATTEMPTS must be a positive integer"
+
+case "$FIRST_PASS_ATTEMPTS" in
+	''|*[!0-9]*) die "CLARK_REFSEQ_FIRST_PASS_ATTEMPTS must be a positive integer" ;;
+esac
+[ "$FIRST_PASS_ATTEMPTS" -gt 0 ] || die "CLARK_REFSEQ_FIRST_PASS_ATTEMPTS must be a positive integer"
 
 case "$RETRY_DELAY" in
 	''|*[!0-9]*) die "CLARK_REFSEQ_RETRY_DELAY must be a non-negative integer" ;;
@@ -262,6 +268,8 @@ fetch_url_to_status() {
 	url="$1"
 	source="$2"
 	status_file="$3"
+	max_attempts="$4"
+	failure_status="$5"
 	output=${url##*/}
 
 	if [ -s "$output" ]; then
@@ -283,7 +291,7 @@ fetch_url_to_status() {
 	fi
 
 	attempt=1
-	while [ "$attempt" -le "$DOWNLOAD_ATTEMPTS" ]; do
+	while [ "$attempt" -le "$max_attempts" ]; do
 		if run_sequence_download_once "$url" "$partial"; then
 			:
 		fi
@@ -293,15 +301,15 @@ fetch_url_to_status() {
 			return 0
 		fi
 		rm -f "$partial"
-		if [ "$attempt" -lt "$DOWNLOAD_ATTEMPTS" ] && [ "$RETRY_DELAY" -gt 0 ]; then
+		if [ "$attempt" -lt "$max_attempts" ] && [ "$RETRY_DELAY" -gt 0 ]; then
 			sleep $((RETRY_DELAY * attempt))
 		fi
 		attempt=$((attempt + 1))
 	done
 
-	echo "Failed to download $url after $DOWNLOAD_ATTEMPTS attempt(s)" >&2
 	rm -f "$partial"
-	return 1
+	record_manifest_line "$status_file" "download" "$source" "$url" "$(pwd)/$output" "$failure_status"
+	return 0
 }
 
 download_assembly_source() {
@@ -407,15 +415,16 @@ validate_download_list() {
 }
 
 report_download_progress() {
-	completed="$1"
-	total="$2"
+	label="$1"
+	completed="$2"
+	total="$3"
 	if [ "$total" -eq 0 ]; then
-		message="RefSeq download progress: 0/0 files complete (100%)."
+		message="$label: 0/0 files complete (100%)."
 		if [ -t 1 ]; then printf '\r%s\n' "$message"; else echo "$message"; fi
 		return 0
 	fi
 	percent=$((completed * 100 / total))
-	message="RefSeq download progress: $completed/$total files complete ($percent%)."
+	message="$label: $completed/$total files complete ($percent%)."
 	if [ -t 1 ]; then
 		if [ "$completed" -ge "$total" ]; then
 			printf '\r%s\n' "$message"
@@ -425,6 +434,70 @@ report_download_progress() {
 	else
 		echo "$message"
 	fi
+}
+
+run_download_pass() {
+	list_file="$1"
+	status_prefix="$2"
+	max_attempts="$3"
+	failure_status="$4"
+	progress_label="$5"
+	total=$(wc -l < "$list_file" | tr -d ' ')
+
+	[ "$total" -gt 0 ] || return 0
+
+	job_count=0
+	job_index=0
+	completed=0
+	progress_step=$((total / 100))
+	[ "$progress_step" -gt 0 ] || progress_step=1
+	[ "$progress_step" -le 100 ] || progress_step=100
+	next_report="$progress_step"
+	report_download_progress "$progress_label" 0 "$total"
+	while IFS='	' read -r source genome_url || [ -n "$genome_url" ]; do
+		[ -n "$genome_url" ] || continue
+		job_index=$((job_index + 1))
+		fetch_url_to_status "$genome_url" "$source" "$status_dir/$status_prefix.$job_index.status.tsv" "$max_attempts" "$failure_status" &
+		job_count=$((job_count + 1))
+		if [ "$job_count" -ge "$THREADS" ]; then
+			wait
+			completed=$((completed + job_count))
+			if [ -t 1 ] || [ "$completed" -ge "$next_report" ] || [ "$completed" -ge "$total" ]; then
+				report_download_progress "$progress_label" "$completed" "$total"
+				while [ "$next_report" -le "$completed" ]; do
+					next_report=$((next_report + progress_step))
+				done
+			fi
+			job_count=0
+		fi
+	done < "$list_file"
+	if [ "$job_count" -gt 0 ]; then
+		wait
+		completed=$((completed + job_count))
+		report_download_progress "$progress_label" "$completed" "$total"
+	fi
+}
+
+collect_deferred_downloads() {
+	find "$status_dir" -type f -name 'initial.*.status.tsv' -exec awk -F '\t' '
+		$7 == "deferred" { print $4 "\t" $5 }
+	' {} + > "$retry_list"
+}
+
+report_remaining_failures() {
+	find "$status_dir" -type f -name '*.status.tsv' -exec awk -F '\t' '
+		$7 == "failed" { print $4 "\t" $5 }
+	' {} + > "$failed_list"
+	[ -s "$failed_list" ] || return 0
+
+	failed_count=$(wc -l < "$failed_list" | tr -d ' ')
+	echo "Failed to download $failed_count RefSeq genome file(s) after deferred retries." >&2
+	echo "First failed URLs:" >&2
+	sed -n '1,20p' "$failed_list" | while IFS='	' read -r failed_source failed_url || [ -n "$failed_url" ]; do
+		[ -n "$failed_url" ] || continue
+		echo "  [$failed_source] $failed_url" >&2
+	done
+	die "RefSeq download incomplete; rerun the same command to resume and retry failed files"
 }
 
 download_url_list() {
@@ -443,40 +516,21 @@ download_url_list() {
 	status_dir="$DBDR/.$DB.download-status.$$"
 	rm -rf "$status_dir"
 	mkdir -p "$status_dir"
-	job_count=0
-	job_index=0
-	completed=0
-	progress_step=$((total / 100))
-	[ "$progress_step" -gt 0 ] || progress_step=1
-	[ "$progress_step" -le 100 ] || progress_step=100
-	next_report="$progress_step"
-	report_download_progress 0 "$total"
-	while IFS='	' read -r source genome_url || [ -n "$genome_url" ]; do
-		[ -n "$genome_url" ] || continue
-		job_index=$((job_index + 1))
-		fetch_url_to_status "$genome_url" "$source" "$status_dir/$job_index.tsv" &
-		job_count=$((job_count + 1))
-		if [ "$job_count" -ge "$THREADS" ]; then
-			wait || die "failed to download one or more RefSeq genomes"
-			completed=$((completed + job_count))
-			if [ -t 1 ] || [ "$completed" -ge "$next_report" ] || [ "$completed" -ge "$total" ]; then
-				report_download_progress "$completed" "$total"
-				while [ "$next_report" -le "$completed" ]; do
-					next_report=$((next_report + progress_step))
-				done
-			fi
-			job_count=0
-		fi
-	done < "$DOWNLOAD_LIST"
-	if [ "$job_count" -gt 0 ]; then
-		wait || die "failed to download one or more RefSeq genomes"
-		completed=$((completed + job_count))
-		report_download_progress "$completed" "$total"
+	retry_list="$status_dir/deferred.urls.tsv"
+	failed_list="$status_dir/failed.urls.tsv"
+
+	run_download_pass "$DOWNLOAD_LIST" initial "$FIRST_PASS_ATTEMPTS" deferred "RefSeq download progress"
+	collect_deferred_downloads
+	if [ -s "$retry_list" ]; then
+		deferred_count=$(wc -l < "$retry_list" | tr -d ' ')
+		echo "Retrying $deferred_count deferred RefSeq download(s) after the first pass."
+		run_download_pass "$retry_list" retry "$DOWNLOAD_ATTEMPTS" failed "RefSeq deferred retry progress"
 	fi
 
 	if [ -n "$(find "$status_dir" -type f -print -quit)" ]; then
-		find "$status_dir" -type f -name '*.tsv' -exec cat {} + >> "$MANIFEST"
+		find "$status_dir" -type f -name '*.status.tsv' -exec cat {} + >> "$MANIFEST"
 	fi
+	report_remaining_failures
 	rm -rf "$status_dir"
 }
 

--- a/scripts/download_RefSeqDB.sh
+++ b/scripts/download_RefSeqDB.sh
@@ -25,7 +25,17 @@
 set -eu
 
 usage() {
-	echo "Usage: $0 [--dry-run] <Directory for the sequences> <Database: bacteria, viruses, plasmid, plastid, protozoa, fungi or human> "
+	cat <<USAGE
+Usage: $0 [options] <Directory for the sequences> <Database: bacteria, viruses, plasmid, plastid, protozoa, fungi or human>
+
+Options:
+  --dry-run                         Plan downloads without fetching sequence files.
+  --threads <N>                     Download up to N sequence files at a time (default: 1).
+  --resume                          Keep existing sequence files and resume partial downloads.
+  --refseq-category <all|representative|reference>
+                                    Filter RefSeq assembly summaries by refseq_category (default: all).
+  --assembly-level <level|all>      Filter RefSeq assembly summaries by assembly_level (default: Complete Genome).
+USAGE
 }
 
 die() {
@@ -33,17 +43,60 @@ die() {
 	exit 1
 }
 
-if [ "${1:-}" = "--dry-run" ]; then
-	DRY_RUN=1
-	shift
-else
-	DRY_RUN=${CLARK_REFSEQ_DRY_RUN:-0}
-fi
+DRY_RUN=${CLARK_REFSEQ_DRY_RUN:-0}
+THREADS=${CLARK_REFSEQ_THREADS:-1}
+RESUME=${CLARK_REFSEQ_RESUME:-0}
+REFSEQ_CATEGORY=${CLARK_REFSEQ_CATEGORY:-all}
+ASSEMBLY_LEVEL=${CLARK_REFSEQ_ASSEMBLY_LEVEL:-Complete Genome}
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--dry-run)
+			DRY_RUN=1
+			shift
+			;;
+		--threads)
+			[ "$#" -ge 2 ] || die "--threads requires a positive integer"
+			THREADS="$2"
+			shift 2
+			;;
+		--resume)
+			RESUME=1
+			shift
+			;;
+		--refseq-category)
+			[ "$#" -ge 2 ] || die "--refseq-category requires all, representative, or reference"
+			REFSEQ_CATEGORY="$2"
+			shift 2
+			;;
+		--assembly-level)
+			[ "$#" -ge 2 ] || die "--assembly-level requires a value"
+			ASSEMBLY_LEVEL="$2"
+			shift 2
+			;;
+		--*)
+			die "unrecognized option: $1"
+			;;
+		*)
+			break
+			;;
+	esac
+done
 
 if [ "$#" -ne 2 ]; then
 	usage
 	exit 1
 fi
+
+case "$THREADS" in
+	''|*[!0-9]*) die "--threads must be a positive integer" ;;
+esac
+[ "$THREADS" -gt 0 ] || die "--threads must be a positive integer"
+
+case "$REFSEQ_CATEGORY" in
+	all|representative|reference) ;;
+	*) die "--refseq-category must be all, representative, or reference" ;;
+esac
 
 DIR=${CLARK_HOME:-$(CDPATH= cd "$(dirname "$0")/.." && pwd -P)}
 DBDR="$1"
@@ -61,6 +114,7 @@ DBDR=$(CDPATH= cd "$DBDR" && pwd -P)
 MARKER="$DBDR/.$DB"
 MANIFEST="$DBDR/.$DB.download_manifest.tsv"
 PROVENANCE="$DBDR/.$DB.provenance.tsv"
+DOWNLOAD_LIST="$DBDR/.$DB.download_urls.tsv"
 
 db_directory_name() {
 	case "$1" in
@@ -116,17 +170,26 @@ needs_sequence_split() {
 
 init_reports() {
 	printf 'timestamp_utc\tdatabase\taction\tsource\turl\tlocal_path\tstatus\n' > "$MANIFEST"
-	printf 'database\tsource\taccession\tseq_rel_date\tassembly_level\tversion_status\turl\n' > "$PROVENANCE"
+	printf 'database\tsource\taccession\ttaxid\tspecies_taxid\tseq_rel_date\tassembly_level\tversion_status\turl\n' > "$PROVENANCE"
+	: > "$DOWNLOAD_LIST"
+}
+
+record_manifest_line() {
+	printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+		"$RUN_STARTED_UTC" "$DB" "$2" "$3" "$4" "$5" "$6" >> "$1"
 }
 
 record_manifest() {
-	printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-		"$RUN_STARTED_UTC" "$DB" "$1" "$2" "$3" "$4" "$5" >> "$MANIFEST"
+	record_manifest_line "$MANIFEST" "$1" "$2" "$3" "$4" "$5"
 }
 
 record_provenance() {
-	printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-		"$DB" "$1" "$2" "$3" "$4" "$5" "$6" >> "$PROVENANCE"
+	printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+		"$DB" "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" >> "$PROVENANCE"
+}
+
+append_download_url() {
+	printf '%s\t%s\n' "$1" "$2" >> "$DOWNLOAD_LIST"
 }
 
 accession_from_url() {
@@ -142,11 +205,6 @@ fetch_to_file() {
 	output="$2"
 	source="$3"
 
-	if [ "$DRY_RUN" = "1" ]; then
-		record_manifest "plan" "$source" "$url" "$output" "dry-run"
-		return 0
-	fi
-
 	if command -v wget >/dev/null 2>&1; then
 		wget -O "$output" "$url"
 	elif command -v curl >/dev/null 2>&1; then
@@ -156,59 +214,83 @@ fetch_to_file() {
 	fi
 
 	[ -s "$output" ] || die "failed to download $url"
-	record_manifest "download" "$source" "$url" "$(pwd)/$output" "downloaded"
+	record_manifest "metadata" "$source" "$url" "$output" "downloaded"
 }
 
-fetch_url() {
+fetch_url_to_status() {
 	url="$1"
 	source="$2"
+	status_file="$3"
 	output=${url##*/}
 
-	if [ "$DRY_RUN" = "1" ]; then
-		record_manifest "plan" "$source" "$url" "$output" "dry-run"
+	if [ -s "$output" ]; then
+		record_manifest_line "$status_file" "download" "$source" "$url" "$(pwd)/$output" "skipped-existing"
+		return 0
+	fi
+	if [ "${output%.gz}" != "$output" ] && [ -s "${output%.gz}" ]; then
+		record_manifest_line "$status_file" "download" "$source" "$url" "$(pwd)/${output%.gz}" "skipped-existing"
 		return 0
 	fi
 
+	partial="$output.part"
+	if [ "$RESUME" != "1" ]; then
+		rm -f "$partial"
+	fi
+
 	if command -v wget >/dev/null 2>&1; then
-		wget "$url"
+		if [ "$RESUME" = "1" ]; then
+			wget -c -O "$partial" "$url"
+		else
+			wget -O "$partial" "$url"
+		fi
 	elif command -v curl >/dev/null 2>&1; then
-		curl -fLO "$url"
+		if [ "$RESUME" = "1" ]; then
+			curl -fL -C - -o "$partial" "$url"
+		else
+			curl -fL -o "$partial" "$url"
+		fi
 	else
 		die "neither wget nor curl is available"
 	fi
 
-	[ -s "$output" ] || die "failed to download $url"
-	record_manifest "download" "$source" "$url" "$(pwd)/$output" "downloaded"
+	[ -s "$partial" ] || return 1
+	mv "$partial" "$output"
+	record_manifest_line "$status_file" "download" "$source" "$url" "$(pwd)/$output" "downloaded"
 }
 
 download_assembly_source() {
 	source="$1"
 	summary_url="https://ftp.ncbi.nlm.nih.gov/genomes/refseq/$source/assembly_summary.txt"
-	summary_file="assembly_summary.$source.txt"
-	urls_file=".$DB.$source.urls"
+	summary_file="$DBDR/.$DB.assembly_summary.$source.txt"
 
 	fetch_to_file "$summary_url" "$summary_file" "$source"
-	if [ "$DRY_RUN" = "1" ]; then
-		record_provenance "$source" "assembly_summary" "NA" "Complete Genome" "latest" "$summary_url"
-		return 0
-	fi
 
-	awk -F '\t' -v db="$DB" -v source="$source" -v provenance="$PROVENANCE" '
-		BEGIN { OFS = "\t" }
-		$12 == "Complete Genome" && $11 == "latest" && $20 != "" {
-			n = split($20, path_parts, "/")
-			url = $20 "/" path_parts[n] "_genomic.fna.gz"
-			print db, source, $1, $15, $12, $11, url >> provenance
-			print url
-		}
-	' "$summary_file" > "$urls_file"
+	awk -F '\t' \
+		-v db="$DB" \
+		-v source="$source" \
+		-v provenance="$PROVENANCE" \
+		-v category="$REFSEQ_CATEGORY" \
+		-v assembly_level="$ASSEMBLY_LEVEL" \
+		-v download_list="$DOWNLOAD_LIST" '
+			BEGIN { OFS = "\t" }
+			$0 !~ /^#/ && $11 == "latest" && $20 != "" {
+				if (assembly_level != "all" && $12 != assembly_level) {
+					next
+				}
+				if (category == "representative" && $5 != "representative genome") {
+					next
+				}
+				if (category == "reference" && $5 != "reference genome") {
+					next
+				}
+				n = split($20, path_parts, "/")
+				url = $20 "/" path_parts[n] "_genomic.fna.gz"
+				print db, source, $1, $6, $7, $15, $12, $11, url >> provenance
+				print source, url >> download_list
+			}
+		' "$summary_file"
 
-	while IFS= read -r genome_url || [ -n "$genome_url" ]; do
-		[ -n "$genome_url" ] || continue
-		fetch_url "$genome_url" "$source"
-	done < "$urls_file"
-
-	rm -f "$summary_file" "$urls_file"
+	rm -f "$summary_file"
 }
 
 download_static_urls() {
@@ -228,15 +310,15 @@ download_static_urls() {
 		$0 !~ /^#/ && NF >= 3 && $1 == db { print $2 " " $3 }
 	' "$STATIC_URLS_FILE" | while read -r source genome_url; do
 		[ -n "$genome_url" ] || continue
-		record_provenance "$source" "$(accession_from_url "$genome_url")" "NA" "static" "latest" "$genome_url"
-		fetch_url "$genome_url" "$source"
+		record_provenance "$source" "$(accession_from_url "$genome_url")" "NA" "NA" "NA" "static" "latest" "$genome_url"
+		append_download_url "$source" "$genome_url"
 	done
 }
 
 decompress_gz_files() {
 	find "$(pwd)" -type f -name '*.gz' -print | while IFS= read -r gz_file || [ -n "$gz_file" ]; do
 		[ -n "$gz_file" ] || continue
-		gunzip "$gz_file"
+		gunzip -f "$gz_file"
 	done
 }
 
@@ -251,6 +333,41 @@ write_sequence_marker() {
 	find "$(pwd)" -name "$(sequence_pattern)" > "$MARKER"
 }
 
+download_url_list() {
+	total=$(wc -l < "$DOWNLOAD_LIST" | tr -d ' ')
+	echo "Selected $total $DB RefSeq genome(s) using assembly_level=$ASSEMBLY_LEVEL and refseq_category=$REFSEQ_CATEGORY."
+
+	if [ "$DRY_RUN" = "1" ]; then
+		while IFS='	' read -r source genome_url || [ -n "$genome_url" ]; do
+			[ -n "$genome_url" ] || continue
+			record_manifest "plan" "$source" "$genome_url" "$DATA_DIR/${genome_url##*/}" "dry-run"
+		done < "$DOWNLOAD_LIST"
+		return 0
+	fi
+
+	status_dir="$DBDR/.$DB.download-status.$$"
+	rm -rf "$status_dir"
+	mkdir -p "$status_dir"
+	job_count=0
+	job_index=0
+	while IFS='	' read -r source genome_url || [ -n "$genome_url" ]; do
+		[ -n "$genome_url" ] || continue
+		job_index=$((job_index + 1))
+		fetch_url_to_status "$genome_url" "$source" "$status_dir/$job_index.tsv" &
+		job_count=$((job_count + 1))
+		if [ "$job_count" -ge "$THREADS" ]; then
+			wait || die "failed to download one or more RefSeq genomes"
+			job_count=0
+		fi
+	done < "$DOWNLOAD_LIST"
+	wait || die "failed to download one or more RefSeq genomes"
+
+	if [ -n "$(find "$status_dir" -type f -print -quit)" ]; then
+		cat "$status_dir"/*.tsv >> "$MANIFEST"
+	fi
+	rm -rf "$status_dir"
+}
+
 if [ "$DRY_RUN" != "1" ] && [ -s "$MARKER" ]; then
 	echo "$(display_name "$DB") sequences already in $DBDR."
 	exit 0
@@ -260,10 +377,16 @@ DATA_DIR="$DBDR/$(db_directory_name "$DB")"
 if [ "$DRY_RUN" = "1" ]; then
 	echo "Dry run: planning $(display_name "$DB") RefSeq downloads."
 else
-	rm -Rf "$DATA_DIR" "$DBDR"/".$DB".*
-	mkdir -m 775 "$DATA_DIR"
+	if [ "$RESUME" = "1" ]; then
+		rm -f "$DBDR"/".$DB".download_manifest.tsv "$DBDR"/".$DB".provenance.tsv "$DBDR"/".$DB".download_urls.tsv
+		mkdir -p "$DATA_DIR"
+	else
+		rm -Rf "$DATA_DIR" "$DBDR"/".$DB".*
+		mkdir -m 775 "$DATA_DIR"
+	fi
 	cd "$DATA_DIR" || exit 1
 	echo "Downloading now $(display_name "$DB") RefSeq genomes."
+	echo "Download threads: $THREADS; resume: $RESUME; RefSeq category: $REFSEQ_CATEGORY; assembly level: $ASSEMBLY_LEVEL."
 fi
 
 init_reports
@@ -272,6 +395,7 @@ for source in $(assembly_sources); do
 	download_assembly_source "$source"
 done
 download_static_urls
+download_url_list
 
 if [ "$DRY_RUN" = "1" ]; then
 	echo "Dry run complete."

--- a/scripts/download_taxondata.sh
+++ b/scripts/download_taxondata.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 usage() {
-	echo "Usage: $0 <Directory: directory to store taxonomy data>"
+	echo "Usage: $0 [--skip-accession-maps] <Directory: directory to store taxonomy data>"
 }
 
 die() {
@@ -24,6 +24,12 @@ download_file() {
 	fi
 }
 
+SKIP_ACCESSION_MAPS=0
+if [ "${1:-}" = "--skip-accession-maps" ]; then
+	SKIP_ACCESSION_MAPS=1
+	shift
+fi
+
 if [ "$#" -ne 1 ]; then
 	usage
 	exit 1
@@ -40,21 +46,28 @@ mkdir -p "$TARGET_DIR"
 cd "$TARGET_DIR"
 
 echo "Downloading NCBI taxonomy data..."
-download_file "https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/nucl_gb.accession2taxid.gz" "nucl_gb.accession2taxid.gz"
-download_file "https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/nucl_wgs.accession2taxid.gz" "nucl_wgs.accession2taxid.gz"
+if [ "$SKIP_ACCESSION_MAPS" != "1" ]; then
+	download_file "https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/nucl_gb.accession2taxid.gz" "nucl_gb.accession2taxid.gz"
+	download_file "https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/nucl_wgs.accession2taxid.gz" "nucl_wgs.accession2taxid.gz"
+fi
 download_file "https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz" "taxdump.tar.gz"
 
-if [ -s "nucl_gb.accession2taxid.gz" ] && [ -s "nucl_wgs.accession2taxid.gz" ] && [ -s "taxdump.tar.gz" ]; then
+if { [ "$SKIP_ACCESSION_MAPS" = "1" ] || { [ -s "nucl_gb.accession2taxid.gz" ] && [ -s "nucl_wgs.accession2taxid.gz" ]; }; } && [ -s "taxdump.tar.gz" ]; then
 	echo "Uncompressing taxonomy data..."
-	gunzip -f "nucl_wgs.accession2taxid.gz"
-	gunzip -f "nucl_gb.accession2taxid.gz"
+	if [ "$SKIP_ACCESSION_MAPS" != "1" ]; then
+		gunzip -f "nucl_wgs.accession2taxid.gz"
+		gunzip -f "nucl_gb.accession2taxid.gz"
+	fi
 	tar -zxf "taxdump.tar.gz"
 else
 	die "failed to download one or more taxonomy files"
 fi
 
-if [ -s "nucl_gb.accession2taxid" ] && [ -s "nucl_wgs.accession2taxid" ] && [ -s "nodes.dmp" ] && [ -s "merged.dmp" ] && [ -s "names.dmp" ]; then
-	cat "nucl_gb.accession2taxid" "nucl_wgs.accession2taxid" > "nucl_accss"
+if [ -s "nodes.dmp" ] && [ -s "merged.dmp" ] && [ -s "names.dmp" ]; then
+	if [ "$SKIP_ACCESSION_MAPS" != "1" ]; then
+		[ -s "nucl_gb.accession2taxid" ] && [ -s "nucl_wgs.accession2taxid" ] || die "failed to unpack accession-to-taxid maps"
+		cat "nucl_gb.accession2taxid" "nucl_wgs.accession2taxid" > "nucl_accss"
+	fi
 	touch "../.taxondata"
 	echo "Taxonomy data ready in $TARGET_DIR"
 else

--- a/scripts/make_metadata.sh
+++ b/scripts/make_metadata.sh
@@ -34,6 +34,81 @@ supported_database() {
 	esac
 }
 
+build_refseq_taxid_map_from_provenance() {
+	local provenance="$DBDR/.$DB.provenance.tsv"
+	[ -s "$provenance" ] || return 1
+
+	case "$DB" in
+		bacteria|viruses|protozoa|fungi) ;;
+		*) return 1 ;;
+	esac
+
+	awk -F '\t' -v provenance="$provenance" '
+		BEGIN {
+			while ((getline line < provenance) > 0) {
+				ncols = split(line, cols, FS)
+				if (line ~ /^database\t/) {
+					for (i = 1; i <= ncols; i++) {
+						header[cols[i]] = i
+					}
+					continue
+				}
+				if (!("accession" in header) || !("taxid" in header) || !("url" in header)) {
+					exit 2
+				}
+				taxid = cols[header["taxid"]]
+				if (taxid !~ /^[0-9]+$/ || taxid == "0") {
+					continue
+				}
+				file_name = cols[header["url"]]
+				sub(/^.*\//, "", file_name)
+				sub(/\.gz$/, "", file_name)
+				taxid_by_file[file_name] = cols[header["accession"]] "\t" taxid
+			}
+			close(provenance)
+		}
+		{
+			file_name = $0
+			sub(/^.*\//, "", file_name)
+			if (file_name in taxid_by_file) {
+				print $0 "\t" taxid_by_file[file_name]
+				matched++
+			} else {
+				missing++
+			}
+		}
+		END {
+			if (matched == 0 || missing > 0) {
+				exit 1
+			}
+		}
+	' "$DBDR/.$DB"
+}
+
+ensure_taxonomy_data() {
+	local require_accession_maps="$1"
+	local downloader_args=()
+	if [ "$require_accession_maps" != "1" ]; then
+		downloader_args=(--skip-accession-maps)
+	fi
+
+	if [ ! -d "$DBDR/$TAXDR" ]; then
+		echo "Taxonomy data missing. The program will download data to $DBDR/$TAXDR."
+		mkdir -p "$DBDR/$TAXDR"
+		"$LDIR/scripts/download_taxondata.sh" "${downloader_args[@]}" "$DBDR/$TAXDR"
+	fi
+
+	if [ ! -f "$DBDR/.taxondata" ] || { [ "$require_accession_maps" = "1" ] && [ ! -s "$DBDR/$TAXDR/nucl_accss" ]; }; then
+		echo "Failed to find required taxonomy files. The program will try to download them..."
+		"$LDIR/scripts/download_taxondata.sh" "${downloader_args[@]}" "$DBDR/$TAXDR"
+	fi
+
+	[ -f "$DBDR/.taxondata" ] || die "failed to find taxonomy files"
+	if [ "$require_accession_maps" = "1" ]; then
+		[ -s "$DBDR/$TAXDR/nucl_accss" ] || die "failed to find accession-to-taxid maps"
+	fi
+}
+
 if [ "$#" -lt 2 ]; then
 	usage
 	exit 1
@@ -48,18 +123,6 @@ LDIR="${CLARK_HOME:-$(cd "$SCRIPT_DIR/.." >/dev/null 2>&1 && pwd)}"
 supported_database "$DB" || die "unsupported database '$DB'. Supported: bacteria, viruses, plasmid, plastid, protozoa, fungi, human, custom."
 
 mkdir -p "$DBDR/Custom"
-
-if [ ! -d "$DBDR/$TAXDR" ]; then
-	echo "Taxonomy data missing. The program will download data to $DBDR/$TAXDR."
-	mkdir -p "$DBDR/$TAXDR"
-	"$LDIR/scripts/download_taxondata.sh" "$DBDR/$TAXDR"
-fi
-
-if [ ! -f "$DBDR/.taxondata" ]; then
-	echo "Failed to find taxonomy files. The program will try to download them..."
-	"$LDIR/scripts/download_taxondata.sh" "$DBDR/$TAXDR"
-	[ -f "$DBDR/.taxondata" ] || die "failed to find taxonomy files"
-fi
 
 if [ ! -s "$DBDR/.$DB" ]; then
 	if [ "$DB" != "custom" ]; then
@@ -78,6 +141,22 @@ if [ ! -x "$LDIR/exe/getfilesToTaxNodes" ] || [ ! -x "$LDIR/exe/getAccssnTaxID" 
 fi
 
 [ -s "$DBDR/.$DB" ] || die "failed to find $DB sequences"
+
+if [ "$DB" != "human" ] && [ ! -s "$DBDR/.$DB.fileToAccssnTaxID" ]; then
+	tmp_accss="$DBDR/.$DB.fileToAccssnTaxID.tmp.$$"
+	if build_refseq_taxid_map_from_provenance > "$tmp_accss"; then
+		mv "$tmp_accss" "$DBDR/.$DB.fileToAccssnTaxID"
+		echo "Built $DB.fileToAccssnTaxID from RefSeq provenance."
+	else
+		rm -f "$tmp_accss"
+	fi
+fi
+
+require_accession_maps=0
+if [ "$DB" != "human" ] && [ ! -s "$DBDR/.$DB.fileToAccssnTaxID" ]; then
+	require_accession_maps=1
+fi
+ensure_taxonomy_data "$require_accession_maps"
 
 if [ "$DB" = "human" ]; then
 	if [ ! -s "$DBDR/.$DB" ]; then

--- a/scripts/set_targets.sh
+++ b/scripts/set_targets.sh
@@ -13,8 +13,8 @@ Taxonomy rank:
   --species (default), --genus, --family, --order, --class, --phylum
 
 Download options for RefSeq databases:
-  --download-threads <N>              Download up to N sequence files at a time.
-  --resume-downloads                  Keep existing sequence files and resume partial downloads.
+  --download-threads <N>              Download up to N sequence files at a time (default: 8).
+  --resume-downloads                  Keep existing sequence files and resume partial downloads (default: on).
   --refseq-category <all|representative|reference>
                                       Select all, representative, or reference RefSeq assemblies.
   --assembly-level <level|all>        Select a RefSeq assembly_level (default: Complete Genome).
@@ -58,8 +58,8 @@ DBDR_INPUT="$1"
 shift
 RANK=0
 DATABASES=()
-DOWNLOAD_THREADS="${CLARK_REFSEQ_THREADS:-1}"
-RESUME_DOWNLOADS="${CLARK_REFSEQ_RESUME:-0}"
+DOWNLOAD_THREADS="${CLARK_REFSEQ_THREADS:-8}"
+RESUME_DOWNLOADS="${CLARK_REFSEQ_RESUME:-1}"
 REFSEQ_CATEGORY="${CLARK_REFSEQ_CATEGORY:-all}"
 ASSEMBLY_LEVEL="${CLARK_REFSEQ_ASSEMBLY_LEVEL:-Complete Genome}"
 

--- a/scripts/set_targets.sh
+++ b/scripts/set_targets.sh
@@ -11,6 +11,13 @@ Database choices:
 
 Taxonomy rank:
   --species (default), --genus, --family, --order, --class, --phylum
+
+Download options for RefSeq databases:
+  --download-threads <N>              Download up to N sequence files at a time.
+  --resume-downloads                  Keep existing sequence files and resume partial downloads.
+  --refseq-category <all|representative|reference>
+                                      Select all, representative, or reference RefSeq assemblies.
+  --assembly-level <level|all>        Select a RefSeq assembly_level (default: Complete Genome).
 USAGE
 }
 
@@ -51,22 +58,62 @@ DBDR_INPUT="$1"
 shift
 RANK=0
 DATABASES=()
+DOWNLOAD_THREADS="${CLARK_REFSEQ_THREADS:-1}"
+RESUME_DOWNLOADS="${CLARK_REFSEQ_RESUME:-0}"
+REFSEQ_CATEGORY="${CLARK_REFSEQ_CATEGORY:-all}"
+ASSEMBLY_LEVEL="${CLARK_REFSEQ_ASSEMBLY_LEVEL:-Complete Genome}"
 
-for arg in "$@"; do
-	case "$arg" in
+while [ "$#" -gt 0 ]; do
+	case "$1" in
 		--species|--genus|--family|--order|--class|--phylum)
-			RANK="$(rank_value "$arg")"
+			RANK="$(rank_value "$1")"
+			shift
+			;;
+		--download-threads)
+			[ "$#" -ge 2 ] || die "--download-threads requires a positive integer"
+			DOWNLOAD_THREADS="$2"
+			shift 2
+			;;
+		--resume-downloads)
+			RESUME_DOWNLOADS=1
+			shift
+			;;
+		--refseq-category)
+			[ "$#" -ge 2 ] || die "--refseq-category requires all, representative, or reference"
+			REFSEQ_CATEGORY="$2"
+			shift 2
+			;;
+		--assembly-level)
+			[ "$#" -ge 2 ] || die "--assembly-level requires a value"
+			ASSEMBLY_LEVEL="$2"
+			shift 2
 			;;
 		--*)
-			die "unrecognized taxonomy rank '$arg'"
+			die "unrecognized option '$1'"
 			;;
 		*)
-			DATABASES+=("$arg")
+			DATABASES+=("$1")
+			shift
 			;;
 	esac
 done
 
 [ "${#DATABASES[@]}" -gt 0 ] || die "choose at least one database"
+
+case "$DOWNLOAD_THREADS" in
+	''|*[!0-9]*) die "--download-threads must be a positive integer" ;;
+esac
+[ "$DOWNLOAD_THREADS" -gt 0 ] || die "--download-threads must be a positive integer"
+
+case "$REFSEQ_CATEGORY" in
+	all|representative|reference) ;;
+	*) die "--refseq-category must be all, representative, or reference" ;;
+esac
+
+export CLARK_REFSEQ_THREADS="$DOWNLOAD_THREADS"
+export CLARK_REFSEQ_RESUME="$RESUME_DOWNLOADS"
+export CLARK_REFSEQ_CATEGORY="$REFSEQ_CATEGORY"
+export CLARK_REFSEQ_ASSEMBLY_LEVEL="$ASSEMBLY_LEVEL"
 
 SCRIPT_DIR="$(script_dir)"
 LDIR="${CLARK_HOME:-$(cd "$SCRIPT_DIR/.." >/dev/null 2>&1 && pwd)}"

--- a/src/parameters.hh
+++ b/src/parameters.hh
@@ -30,7 +30,7 @@
 #ifndef PARAMETERS_HH
 #define PARAMETERS_HH
 
-#define VERSION "1.4.3.0-a"
+#define VERSION "1.4.4.0-a"
 
 #define SB              4       
 #define DBCTRESH	4

--- a/src/parameters_hh
+++ b/src/parameters_hh
@@ -30,7 +30,7 @@
 #ifndef PARAMETERS_HH
 #define PARAMETERS_HH
 
-#define VERSION "1.4.3.0-a"
+#define VERSION "1.4.4.0-a"
 
 #define SB              4       
 #define DBCTRESH        4

--- a/src/parameters_shh
+++ b/src/parameters_shh
@@ -30,7 +30,7 @@
 #ifndef PARAMETERS_HH
 #define PARAMETERS_HH
 
-#define VERSION "1.4.3.0-a"
+#define VERSION "1.4.4.0-a"
 
 #define SB              4       
 #define DBCTRESH	8

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -346,6 +346,51 @@ test_set_targets_records_absolute_db_paths() {
 	pass "set_targets records absolute database paths from another working directory"
 }
 
+test_set_targets_passes_refseq_download_options() {
+	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-set-targets-download-options-test.XXXXXX")"
+	trap 'rm -rf "$tmp"' RETURN
+
+	fake_home="$tmp/fake-home"
+	dbdir_input="$tmp/db"
+	capture="$tmp/capture.txt"
+	mkdir -p "$fake_home/scripts" "$fake_home/exe" "$dbdir_input"
+	dbdir="$(cd -P "$dbdir_input" >/dev/null 2>&1 && pwd)"
+
+	cat > "$fake_home/scripts/make_metadata.sh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+db="$1"
+dbdir="$2"
+{
+	printf 'threads=%s\n' "${CLARK_REFSEQ_THREADS:-}"
+	printf 'resume=%s\n' "${CLARK_REFSEQ_RESUME:-}"
+	printf 'category=%s\n' "${CLARK_REFSEQ_CATEGORY:-}"
+	printf 'assembly=%s\n' "${CLARK_REFSEQ_ASSEMBLY_LEVEL:-}"
+} >> "$CLARK_TEST_CAPTURE"
+printf '%s\n' "$dbdir/ref.fa" > "$dbdir/.$db"
+touch "$dbdir/.taxondata"
+printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$dbdir/ref.fa" "111" "111" "222" "333" "444" "555" "666" > "$dbdir/.$db.fileToTaxIDs"
+STUB
+	cat > "$fake_home/exe/getTargetsDef" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+cat "$1" >/dev/null
+printf 'ref.fa\t111\n'
+STUB
+	chmod +x "$fake_home/scripts/make_metadata.sh" "$fake_home/exe/getTargetsDef"
+
+	CLARK_HOME="$fake_home" \
+	CLARK_TEST_CAPTURE="$capture" \
+		"$REPO_DIR/scripts/set_targets.sh" "$dbdir_input" bacteria --download-threads 4 --resume-downloads --refseq-category representative --assembly-level "Complete Genome" --genus >/dev/null
+
+	grep -Fq "threads=4" "$capture" || fail "set_targets did not pass download thread count"
+	grep -Fq "resume=1" "$capture" || fail "set_targets did not pass resume mode"
+	grep -Fq "category=representative" "$capture" || fail "set_targets did not pass RefSeq category"
+	grep -Fq "assembly=Complete Genome" "$capture" || fail "set_targets did not pass assembly level"
+	grep -Fq -- "-D $dbdir/bacteria_1/" "$fake_home/.settings" || fail "set_targets did not preserve taxonomy rank while parsing download options"
+	pass "set_targets passes RefSeq download options to metadata preparation"
+}
+
 test_update_taxonomy_requires_db_directory() {
 	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-update-taxonomy-state-test.XXXXXX")"
 	trap 'rm -rf "$tmp"' RETURN
@@ -393,6 +438,9 @@ test_refseq_downloader_mocked_assembly_summary() {
 	cat > "$bindir/wget" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
+if [ "${1:-}" = "-c" ]; then
+	shift
+fi
 if [ "$1" = "-O" ]; then
 	out="$2"
 	url="$3"
@@ -404,6 +452,9 @@ if [ "$1" = "-O" ]; then
 				printf 'GCF_999999999.1\tna\tna\tna\trepresentative genome\t10239\t10239\tMock virus\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2024-01-02\tMockVirus1\tCLARK\tna\tna\thttps://example.org/refseq/GCF_999999999.1_MockVirus1\n'
 				printf 'GCF_000000000.1\tna\tna\tna\trepresentative genome\t10239\t10239\tOld virus\tna\tna\treplaced\tComplete Genome\tMajor\tFull\t2020-01-02\tOldVirus\tCLARK\tna\tna\thttps://example.org/refseq/GCF_000000000.1_OldVirus\n'
 			} > "$out"
+			;;
+		*_genomic.fna.gz)
+			printf '>mock-virus\nACGT\n' | gzip > "$out"
 			;;
 		*)
 			echo "unexpected wget -O URL: $url" >&2
@@ -431,6 +482,113 @@ STUB
 	grep -Fq "downloaded" "$dbdir/.viruses.download_manifest.tsv" || fail "RefSeq downloader did not record completed downloads"
 	[ ! -e "$dbdir/Viruses/download.sh" ] || fail "RefSeq downloader generated a legacy download.sh script"
 	pass "RefSeq downloader uses mocked assembly summaries without generated scripts"
+}
+
+test_refseq_downloader_filters_and_resumes() {
+	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-refseq-filter-resume-test.XXXXXX")"
+	trap 'rm -rf "$tmp"' RETURN
+
+	dbdir="$tmp/db"
+	bindir="$tmp/bin"
+	log="$tmp/wget.log"
+	mkdir -p "$bindir" "$dbdir/Bacteria"
+	printf '>existing-bacterium\nACGT\n' | gzip > "$dbdir/Bacteria/GCF_111111111.1_Existing_genomic.fna.gz"
+
+	cat > "$bindir/wget" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "-c" ]; then
+	shift
+fi
+if [ "$1" = "-O" ]; then
+	out="$2"
+	url="$3"
+	printf 'summary %s\n' "$url" >> "$CLARK_TEST_WGET_LOG"
+	case "$url" in
+		*/bacteria/assembly_summary.txt)
+			{
+				printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n'
+				printf 'GCF_111111111.1\tna\tna\tna\trepresentative genome\t111\t111\tExisting bacterium\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2025-01-01\tExisting\tCLARK\tna\tna\thttps://example.org/refseq/GCF_111111111.1_Existing\n'
+				printf 'GCF_222222222.1\tna\tna\tna\trepresentative genome\t222\t222\tNew bacterium\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2025-01-02\tNew\tCLARK\tna\tna\thttps://example.org/refseq/GCF_222222222.1_New\n'
+				printf 'GCF_333333333.1\tna\tna\tna\tna\t333\t333\tUnselected bacterium\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2025-01-03\tUnselected\tCLARK\tna\tna\thttps://example.org/refseq/GCF_333333333.1_Unselected\n'
+				printf 'GCF_444444444.1\tna\tna\tna\trepresentative genome\t444\t444\tDraft bacterium\tna\tna\tlatest\tScaffold\tMajor\tFull\t2025-01-04\tDraft\tCLARK\tna\tna\thttps://example.org/refseq/GCF_444444444.1_Draft\n'
+			} > "$out"
+			;;
+		*/archaea/assembly_summary.txt)
+			{
+				printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n'
+			} > "$out"
+			;;
+		*_genomic.fna.gz)
+			printf 'download %s\n' "$url" >> "$CLARK_TEST_WGET_LOG"
+			printf '>new-bacterium\nTGCA\n' | gzip > "$out"
+			;;
+		*)
+			echo "unexpected wget -O URL: $url" >&2
+			exit 1
+			;;
+	esac
+else
+	url="${@: -1}"
+	printf 'download %s\n' "$url" >> "$CLARK_TEST_WGET_LOG"
+	file="${url##*/}"
+	printf '>new-bacterium\nTGCA\n' | gzip > "$file"
+fi
+STUB
+	chmod +x "$bindir/wget"
+
+	PATH="$bindir:$PATH" \
+	CLARK_TEST_WGET_LOG="$log" \
+	CLARK_REFSEQ_STATIC_URLS="$tmp/missing-static-urls.tsv" \
+		"$REPO_DIR/scripts/download_RefSeqDB.sh" --threads 2 --resume --refseq-category representative "$dbdir" bacteria > "$tmp/downloader.out"
+
+	grep -Fq "Selected 2 bacteria RefSeq genome(s)" "$tmp/downloader.out" || fail "RefSeq downloader did not report filtered bacteria selection"
+	grep -Fq "GCF_111111111.1_Existing_genomic.fna" "$dbdir/.bacteria" || fail "RefSeq downloader lost existing resumed bacteria FASTA"
+	grep -Fq "GCF_222222222.1_New_genomic.fna" "$dbdir/.bacteria" || fail "RefSeq downloader did not list newly downloaded bacteria FASTA"
+	grep -Fq "GCF_222222222.1" "$dbdir/.bacteria.provenance.tsv" || fail "RefSeq downloader did not keep new representative provenance"
+	if grep -Fq "GCF_333333333.1" "$dbdir/.bacteria.provenance.tsv" || grep -Fq "GCF_444444444.1" "$dbdir/.bacteria.provenance.tsv"; then
+		fail "RefSeq downloader provenance includes assemblies outside the requested filters"
+	fi
+	grep -Fq "skipped-existing" "$dbdir/.bacteria.download_manifest.tsv" || fail "RefSeq downloader did not record resumed existing archive"
+	if grep -Fq "download https://example.org/refseq/GCF_111111111.1_Existing" "$log"; then
+		fail "RefSeq downloader re-downloaded an existing archive during resume"
+	fi
+	pass "RefSeq downloader filters RefSeq assemblies and resumes existing archives"
+}
+
+test_make_metadata_uses_refseq_provenance_taxids() {
+	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-refseq-provenance-taxid-test.XXXXXX")"
+	trap 'rm -rf "$tmp"' RETURN
+
+	fake_home="$tmp/fake-home"
+	dbdir="$tmp/db"
+	mkdir -p "$fake_home/scripts" "$fake_home/exe" "$dbdir/Bacteria" "$dbdir/taxonomy"
+	ln -s "$REPO_DIR/scripts/make_metadata.sh" "$fake_home/scripts/make_metadata.sh"
+	ln -s "$REPO_DIR/scripts/download_taxondata.sh" "$fake_home/scripts/download_taxondata.sh"
+	ln -s "$REPO_DIR/scripts/download_RefSeqDB.sh" "$fake_home/scripts/download_RefSeqDB.sh"
+	for binary in getTargetsDef getfilesToTaxNodes getAccssnTaxID; do
+		ln -s "$REPO_DIR/exe/$binary" "$fake_home/exe/$binary"
+	done
+
+	ref="$dbdir/Bacteria/GCF_555555555.1_FastPath_genomic.fna"
+	printf '>NC_555555.1 mock bacteria\nACGT\n' > "$ref"
+	printf '%s\n' "$ref" > "$dbdir/.bacteria"
+	{
+		printf 'database\tsource\taccession\ttaxid\tspecies_taxid\tseq_rel_date\tassembly_level\tversion_status\turl\n'
+		printf 'bacteria\tbacteria\tGCF_555555555.1\t555\t555\t2025-02-01\tComplete Genome\tlatest\thttps://example.org/refseq/GCF_555555555.1_FastPath/GCF_555555555.1_FastPath_genomic.fna.gz\n'
+	} > "$dbdir/.bacteria.provenance.tsv"
+	printf '555 | 2 | species |\n2 | 1 | superkingdom |\n' > "$dbdir/taxonomy/nodes.dmp"
+	printf '1 | 1 |\n' > "$dbdir/taxonomy/merged.dmp"
+	touch "$dbdir/.taxondata"
+
+	CLARK_HOME="$fake_home" "$REPO_DIR/scripts/make_metadata.sh" bacteria "$dbdir" > "$tmp/stdout" 2> "$tmp/stderr"
+
+	grep -Fq "$ref	GCF_555555555.1	555" "$dbdir/.bacteria.fileToAccssnTaxID" || fail "make_metadata did not use RefSeq provenance taxid mapping"
+	grep -Fq "$ref	555	555" "$dbdir/.bacteria.fileToTaxIDs" || fail "make_metadata did not build lineage from provenance taxid mapping"
+	if grep -Fq "Re-building bacteria.fileToAccssnTaxID" "$tmp/stdout" "$tmp/stderr"; then
+		fail "make_metadata fell back to global accession lookup despite usable RefSeq provenance"
+	fi
+	pass "make_metadata uses RefSeq provenance taxids without global accession-map lookup"
 }
 
 test_documentation_script_paths() {
@@ -814,9 +972,12 @@ test_classify_wrapper_paired_light_variant
 test_classify_wrapper_rejects_conflicting_variants
 test_scripts_directory_entrypoint
 test_set_targets_records_absolute_db_paths
+test_set_targets_passes_refseq_download_options
 test_update_taxonomy_requires_db_directory
 test_refseq_downloader_dry_run_manifest
 test_refseq_downloader_mocked_assembly_summary
+test_refseq_downloader_filters_and_resumes
+test_make_metadata_uses_refseq_provenance_taxids
 test_documentation_script_paths
 test_get_targets_def_smoke
 test_get_accssn_taxid_smoke

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -447,6 +447,67 @@ test_update_taxonomy_requires_db_directory() {
 	pass "updateTaxonomy reports missing database configuration"
 }
 
+create_refseq_success_wget_stub() {
+	local bindir="$1"
+	mkdir -p "$bindir"
+	cat > "$bindir/wget" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+quiet=0
+out=""
+url=""
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		-q|--quiet)
+			quiet=1
+			shift
+			;;
+		-c)
+			shift
+			;;
+		-O)
+			out="$2"
+			shift 2
+			;;
+		*)
+			url="$1"
+			shift
+			;;
+	esac
+done
+[ -n "$out" ] || {
+	echo "wget stub missing -O output for $url" >&2
+	exit 1
+}
+if [ -n "${CLARK_TEST_WGET_LOG:-}" ]; then
+	printf 'quiet=%s url=%s\n' "$quiet" "$url" >> "$CLARK_TEST_WGET_LOG"
+fi
+case "$url" in
+	*/viral/assembly_summary.txt)
+		{
+			printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n'
+			printf 'GCF_900000001.1\tna\tna\tna\trepresentative genome\t10239\t10239\tMatrix virus\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tMatrixVirus\tCLARK\tna\tna\thttps://example.org/refseq/GCF_900000001.1_MatrixVirus/\n'
+		} > "$out"
+		;;
+	*/protozoa/assembly_summary.txt)
+		{
+			printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n'
+			printf 'GCF_900000002.1\tna\tna\tna\trepresentative genome\t5759\t5759\tMatrix protozoan\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-02\tMatrixProtozoa\tCLARK\tna\tna\thttps://example.org/refseq/GCF_900000002.1_MatrixProtozoa/\n'
+		} > "$out"
+		;;
+	*.fna.gz)
+		file="${url##*/}"
+		printf '>%s synthetic reference\nACGTACGT\n' "${file%.gz}" | gzip > "$out"
+		;;
+	*)
+		echo "unexpected URL: $url" >&2
+		exit 1
+		;;
+esac
+STUB
+	chmod +x "$bindir/wget"
+}
+
 test_refseq_downloader_dry_run_manifest() {
 	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-refseq-dry-run-test.XXXXXX")"
 	trap 'rm -rf "$tmp"' RETURN
@@ -742,64 +803,62 @@ STUB
 	pass "RefSeq downloader refreshes aggregate progress during parallel downloads"
 }
 
-test_refseq_downloader_mocked_assembly_summary() {
-	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-refseq-mocked-test.XXXXXX")"
+test_refseq_downloader_success_matrix() {
+	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-refseq-success-matrix-test.XXXXXX")"
 	trap 'rm -rf "$tmp"' RETURN
 
-	dbdir="$tmp/db"
 	bindir="$tmp/bin"
 	log="$tmp/wget.log"
-	mkdir -p "$bindir"
+	static_urls="$tmp/static-urls.tsv"
+	create_refseq_success_wget_stub "$bindir"
+	{
+		printf 'plasmid\trefseq_static\thttps://example.org/static/plasmid.1.1.genomic.fna.gz\n'
+		printf 'plastid\trefseq_static\thttps://example.org/static/plastid.1.1.genomic.fna.gz\n'
+	} > "$static_urls"
 
-	cat > "$bindir/wget" <<'STUB'
-#!/usr/bin/env bash
-set -euo pipefail
-while [ "${1:-}" = "-q" ] || [ "${1:-}" = "--quiet" ] || [ "${1:-}" = "-c" ]; do
-	shift
-done
-if [ "$1" = "-O" ]; then
-	out="$2"
-	url="$3"
-	printf '%s\n' "$url" >> "$CLARK_TEST_WGET_LOG"
-	case "$url" in
-		*/assembly_summary.txt)
-			{
-				printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n'
-				printf 'GCF_999999999.1\tna\tna\tna\trepresentative genome\t10239\t10239\tMock virus\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2024-01-02\tMockVirus1\tCLARK\tna\tna\thttps://example.org/refseq/GCF_999999999.1_MockVirus1/\n'
-				printf 'GCF_000000000.1\tna\tna\tna\trepresentative genome\t10239\t10239\tOld virus\tna\tna\treplaced\tComplete Genome\tMajor\tFull\t2020-01-02\tOldVirus\tCLARK\tna\tna\thttps://example.org/refseq/GCF_000000000.1_OldVirus\n'
-			} > "$out"
-			;;
-		*_genomic.fna.gz)
-			printf '>mock-virus\nACGT\n' | gzip > "$out"
-			;;
-		*)
-			echo "unexpected wget -O URL: $url" >&2
-			exit 1
-			;;
-	esac
-else
-	url="$1"
-	printf '%s\n' "$url" >> "$CLARK_TEST_WGET_LOG"
-	file="${url##*/}"
-	printf '>mock-virus\nACGT\n' | gzip > "$file"
-fi
-STUB
-	chmod +x "$bindir/wget"
+	for db in viruses plasmid plastid protozoa; do
+		dbdir="$tmp/db-$db"
+		PATH="$bindir:$PATH" \
+		CLARK_TEST_WGET_LOG="$log" \
+		CLARK_REFSEQ_STATIC_URLS="$static_urls" \
+			"$REPO_DIR/scripts/download_RefSeqDB.sh" --threads 4 "$dbdir" "$db" > "$tmp/$db.out" 2> "$tmp/$db.err"
 
-	PATH="$bindir:$PATH" \
-	CLARK_TEST_WGET_LOG="$log" \
-	CLARK_REFSEQ_STATIC_URLS="$tmp/missing-static-urls.tsv" \
-		"$REPO_DIR/scripts/download_RefSeqDB.sh" "$dbdir" viruses > "$tmp/downloader.out"
-
-	require_file "$dbdir/.viruses"
-	grep -Fq "GCF_999999999.1_MockVirus1_genomic.fna" "$dbdir/.viruses" || fail "RefSeq downloader did not list decompressed virus FASTA"
-	grep -Fq "https://example.org/refseq/GCF_999999999.1_MockVirus1/GCF_999999999.1_MockVirus1_genomic.fna.gz" "$dbdir/.viruses.download_manifest.tsv" ||
-		fail "RefSeq downloader did not normalize trailing slashes in assembly_summary ftp_path"
-	grep -Fq "GCF_999999999.1" "$dbdir/.viruses.provenance.tsv" || fail "RefSeq downloader did not record assembly accession provenance"
-	grep -Fq "2024-01-02" "$dbdir/.viruses.provenance.tsv" || fail "RefSeq downloader did not preserve assembly source date"
-	grep -Fq "downloaded" "$dbdir/.viruses.download_manifest.tsv" || fail "RefSeq downloader did not record completed downloads"
-	[ ! -e "$dbdir/Viruses/download.sh" ] || fail "RefSeq downloader generated a legacy download.sh script"
-	pass "RefSeq downloader uses mocked assembly summaries without generated scripts"
+		require_file "$dbdir/.$db"
+		require_file "$dbdir/.$db.download_manifest.tsv"
+		require_file "$dbdir/.$db.provenance.tsv"
+		grep -Fq "RefSeq download progress:" "$tmp/$db.out" || fail "RefSeq downloader did not report progress for $db"
+		grep -Fq "downloaded" "$dbdir/.$db.download_manifest.tsv" || fail "RefSeq downloader did not record completed downloads for $db"
+		if find "$dbdir" -type f -name '*.part' -print -quit | grep -q .; then
+			fail "RefSeq downloader left partial files for $db"
+		fi
+		case "$db" in
+			viruses)
+				data_dir="Viruses"
+				grep -Fq "GCF_900000001.1_MatrixVirus_genomic.fna" "$dbdir/.viruses" || fail "RefSeq downloader did not list decompressed virus FASTA"
+				grep -Fq "2026-06-01" "$dbdir/.viruses.provenance.tsv" || fail "RefSeq downloader did not preserve virus source date"
+				;;
+			protozoa)
+				data_dir="Protozoa"
+				grep -Fq "GCF_900000002.1_MatrixProtozoa_genomic.fna" "$dbdir/.protozoa" || fail "RefSeq downloader did not list decompressed protozoa FASTA"
+				grep -Fq "2026-06-02" "$dbdir/.protozoa.provenance.tsv" || fail "RefSeq downloader did not preserve protozoa source date"
+				;;
+			plasmid)
+				data_dir="Plasmid"
+				[ "$(find "$dbdir" -type f -name '*.fa' | wc -l | tr -d ' ')" -gt 0 ] || fail "RefSeq downloader did not split $db FASTA records"
+				grep -Fq "$db.1.1.genomic" "$dbdir/.$db.provenance.tsv" || fail "RefSeq downloader did not record static $db provenance"
+				;;
+			plastid)
+				data_dir="Plastid"
+				[ "$(find "$dbdir" -type f -name '*.fa' | wc -l | tr -d ' ')" -gt 0 ] || fail "RefSeq downloader did not split $db FASTA records"
+				grep -Fq "$db.1.1.genomic" "$dbdir/.$db.provenance.tsv" || fail "RefSeq downloader did not record static $db provenance"
+				;;
+		esac
+		[ ! -e "$dbdir/$data_dir/download.sh" ] || fail "RefSeq downloader generated a legacy download.sh script for $db"
+	done
+	if grep -Fq "quiet=0" "$log"; then
+		fail "RefSeq downloader success matrix invoked wget without quiet mode"
+	fi
+	pass "RefSeq downloader completes viruses, plasmid, plastid, and protozoa downloads"
 }
 
 test_refseq_downloader_filters_and_resumes() {
@@ -1299,7 +1358,7 @@ test_refseq_downloader_rejects_malformed_urls_before_download
 test_refseq_downloader_quiet_aggregate_progress
 test_refseq_downloader_retries_parallel_transient_failures
 test_refseq_downloader_reports_early_parallel_progress
-test_refseq_downloader_mocked_assembly_summary
+test_refseq_downloader_success_matrix
 test_refseq_downloader_filters_and_resumes
 test_make_metadata_uses_refseq_provenance_taxids
 test_documentation_script_paths

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -608,6 +608,140 @@ STUB
 	pass "RefSeq downloader uses quiet network commands and aggregate progress"
 }
 
+test_refseq_downloader_retries_parallel_transient_failures() {
+	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-refseq-parallel-retry-test.XXXXXX")"
+	trap 'rm -rf "$tmp"' RETURN
+
+	dbdir="$tmp/db"
+	bindir="$tmp/bin"
+	state="$tmp/state"
+	mkdir -p "$bindir" "$state"
+
+	cat > "$bindir/wget" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+out=""
+url=""
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		-q|--quiet|-c)
+			shift
+			;;
+		-O)
+			out="$2"
+			shift 2
+			;;
+		*)
+			url="$1"
+			shift
+			;;
+	esac
+done
+case "$url" in
+	*/viral/assembly_summary.txt)
+		{
+			printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n'
+			for i in 1 2 3 4 5 6 7 8 9 10; do
+				printf 'GCF_100000%03d.1\tna\tna\tna\trepresentative genome\t10239\t10239\tMock virus %d\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tRetry%d\tCLARK\tna\tna\thttps://example.org/refseq/GCF_100000%03d.1_Retry%d/\n' "$i" "$i" "$i" "$i" "$i"
+			done
+		} > "$out"
+		;;
+	*_genomic.fna.gz)
+		base="${url##*/}"
+		case "$base" in
+			GCF_10000000[3-7].1_*)
+				marker="$CLARK_TEST_STATE/$base.failed-once"
+				if mkdir "$marker" 2>/dev/null; then
+					printf 'partial transfer for %s\n' "$base" > "$out"
+					exit 1
+				fi
+				;;
+		esac
+		printf '>retry-virus\nACGT\n' | gzip > "$out"
+		;;
+	*)
+		echo "unexpected URL: $url" >&2
+		exit 1
+		;;
+esac
+STUB
+	chmod +x "$bindir/wget"
+
+	PATH="$bindir:$PATH" \
+	CLARK_TEST_STATE="$state" \
+	CLARK_REFSEQ_STATIC_URLS="$tmp/missing-static-urls.tsv" \
+	CLARK_REFSEQ_RETRY_DELAY=0 \
+		"$REPO_DIR/scripts/download_RefSeqDB.sh" --threads 8 "$dbdir" viruses > "$tmp/stdout" 2> "$tmp/stderr"
+
+	count=$(find "$dbdir/Viruses" -type f -name '*.fna' | wc -l | tr -d ' ')
+	[ "$count" = "10" ] || fail "RefSeq downloader did not recover all transient parallel download failures"
+	if find "$dbdir/Viruses" -type f -name '*.part' -print -quit | grep -q .; then
+		fail "RefSeq downloader left .part files after successful retries"
+	fi
+	grep -Fq "GCF_100000003.1_Retry3_genomic.fna" "$dbdir/.viruses" ||
+		fail "RefSeq downloader did not list a retried and decompressed FASTA"
+	pass "RefSeq downloader retries transient parallel failures and finalizes archives"
+}
+
+test_refseq_downloader_reports_early_parallel_progress() {
+	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-refseq-progress-refresh-test.XXXXXX")"
+	trap 'rm -rf "$tmp"' RETURN
+
+	dbdir="$tmp/db"
+	bindir="$tmp/bin"
+	mkdir -p "$bindir"
+
+	cat > "$bindir/wget" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+out=""
+url=""
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		-q|--quiet|-c)
+			shift
+			;;
+		-O)
+			out="$2"
+			shift 2
+			;;
+		*)
+			url="$1"
+			shift
+			;;
+	esac
+done
+case "$url" in
+	*/viral/assembly_summary.txt)
+		{
+			printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n'
+			for i in $(seq 1 200); do
+				printf 'GCF_200000%03d.1\tna\tna\tna\trepresentative genome\t10239\t10239\tMock virus %d\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tProgress%d\tCLARK\tna\tna\thttps://example.org/refseq/GCF_200000%03d.1_Progress%d/\n' "$i" "$i" "$i" "$i" "$i"
+			done
+		} > "$out"
+		;;
+	*_genomic.fna.gz)
+		printf '>progress-virus\nACGT\n' | gzip > "$out"
+		;;
+	*)
+		echo "unexpected URL: $url" >&2
+		exit 1
+		;;
+esac
+STUB
+	chmod +x "$bindir/wget"
+
+	PATH="$bindir:$PATH" \
+	CLARK_REFSEQ_STATIC_URLS="$tmp/missing-static-urls.tsv" \
+		"$REPO_DIR/scripts/download_RefSeqDB.sh" --threads 8 "$dbdir" viruses > "$tmp/stdout" 2> "$tmp/stderr"
+
+	grep -Fq "RefSeq download progress: 8/200 files complete" "$tmp/stdout" ||
+		fail "RefSeq downloader did not report progress after the first completed parallel batch"
+	grep -Fq "RefSeq download progress: 200/200 files complete (100%)." "$tmp/stdout" ||
+		fail "RefSeq downloader did not report final aggregate completion"
+	pass "RefSeq downloader refreshes aggregate progress during parallel downloads"
+}
+
 test_refseq_downloader_mocked_assembly_summary() {
 	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-refseq-mocked-test.XXXXXX")"
 	trap 'rm -rf "$tmp"' RETURN
@@ -1163,6 +1297,8 @@ test_refseq_downloader_dry_run_manifest
 test_refseq_downloader_normalizes_ncbi_trailing_slash_paths
 test_refseq_downloader_rejects_malformed_urls_before_download
 test_refseq_downloader_quiet_aggregate_progress
+test_refseq_downloader_retries_parallel_transient_failures
+test_refseq_downloader_reports_early_parallel_progress
 test_refseq_downloader_mocked_assembly_summary
 test_refseq_downloader_filters_and_resumes
 test_make_metadata_uses_refseq_provenance_taxids

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -391,6 +391,45 @@ STUB
 	pass "set_targets passes RefSeq download options to metadata preparation"
 }
 
+test_set_targets_defaults_to_parallel_resume_downloads() {
+	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-set-targets-download-defaults-test.XXXXXX")"
+	trap 'rm -rf "$tmp"' RETURN
+
+	fake_home="$tmp/fake-home"
+	dbdir_input="$tmp/db"
+	capture="$tmp/capture.txt"
+	mkdir -p "$fake_home/scripts" "$fake_home/exe" "$dbdir_input"
+
+	cat > "$fake_home/scripts/make_metadata.sh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+db="$1"
+dbdir="$2"
+{
+	printf 'threads=%s\n' "${CLARK_REFSEQ_THREADS:-}"
+	printf 'resume=%s\n' "${CLARK_REFSEQ_RESUME:-}"
+} >> "$CLARK_TEST_CAPTURE"
+printf '%s\n' "$dbdir/ref.fa" > "$dbdir/.$db"
+touch "$dbdir/.taxondata"
+printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$dbdir/ref.fa" "111" "111" "222" "333" "444" "555" "666" > "$dbdir/.$db.fileToTaxIDs"
+STUB
+	cat > "$fake_home/exe/getTargetsDef" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+cat "$1" >/dev/null
+printf 'ref.fa\t111\n'
+STUB
+	chmod +x "$fake_home/scripts/make_metadata.sh" "$fake_home/exe/getTargetsDef"
+
+	CLARK_HOME="$fake_home" \
+	CLARK_TEST_CAPTURE="$capture" \
+		"$REPO_DIR/scripts/set_targets.sh" "$dbdir_input" bacteria >/dev/null
+
+	grep -Fq "threads=8" "$capture" || fail "set_targets does not default RefSeq download threads to 8"
+	grep -Fq "resume=1" "$capture" || fail "set_targets does not default RefSeq resume mode to on"
+	pass "set_targets defaults to parallel resumable RefSeq downloads"
+}
+
 test_update_taxonomy_requires_db_directory() {
 	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-update-taxonomy-state-test.XXXXXX")"
 	trap 'rm -rf "$tmp"' RETURN
@@ -438,6 +477,9 @@ test_refseq_downloader_normalizes_ncbi_trailing_slash_paths() {
 	cat > "$bindir/wget" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
+while [ "${1:-}" = "-q" ] || [ "${1:-}" = "--quiet" ] || [ "${1:-}" = "-c" ]; do
+	shift
+done
 if [ "$1" = "-O" ]; then
 	out="$2"
 	url="$3"
@@ -495,6 +537,77 @@ test_refseq_downloader_rejects_malformed_urls_before_download() {
 	pass "RefSeq downloader rejects malformed generated URLs before download"
 }
 
+test_refseq_downloader_quiet_aggregate_progress() {
+	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-refseq-quiet-progress-test.XXXXXX")"
+	trap 'rm -rf "$tmp"' RETURN
+
+	dbdir="$tmp/db"
+	bindir="$tmp/bin"
+	log="$tmp/wget.log"
+	mkdir -p "$bindir"
+
+	cat > "$bindir/wget" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+quiet=0
+out=""
+url=""
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		-q|--quiet)
+			quiet=1
+			shift
+			;;
+		-c)
+			shift
+			;;
+		-O)
+			out="$2"
+			shift 2
+			;;
+		*)
+			url="$1"
+			shift
+			;;
+	esac
+done
+printf 'quiet=%s url=%s\n' "$quiet" "$url" >> "$CLARK_TEST_WGET_LOG"
+case "$url" in
+	*/viral/assembly_summary.txt)
+		{
+			printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n'
+			for i in 1 2 3 4 5 6 7 8 9 10; do
+				printf 'GCF_000000%03d.1\tna\tna\tna\trepresentative genome\t10239\t10239\tMock virus %d\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tMock%d\tCLARK\tna\tna\thttps://example.org/refseq/GCF_000000%03d.1_Mock%d/\n' "$i" "$i" "$i" "$i" "$i"
+			done
+		} > "$out"
+		;;
+	*_genomic.fna.gz)
+		printf '>mock-virus\nACGT\n' | gzip > "$out"
+		;;
+	*)
+		echo "unexpected URL: $url" >&2
+		exit 1
+		;;
+esac
+STUB
+	chmod +x "$bindir/wget"
+
+	PATH="$bindir:$PATH" \
+	CLARK_TEST_WGET_LOG="$log" \
+	CLARK_REFSEQ_STATIC_URLS="$tmp/missing-static-urls.tsv" \
+		"$REPO_DIR/scripts/download_RefSeqDB.sh" "$dbdir" viruses > "$tmp/stdout" 2> "$tmp/stderr"
+
+	if grep -Fq "quiet=0" "$log"; then
+		fail "RefSeq downloader invoked wget without quiet mode"
+	fi
+	grep -Fq "RefSeq download progress:" "$tmp/stdout" || fail "RefSeq downloader did not report aggregate progress"
+	grep -Fq "10/10" "$tmp/stdout" || fail "RefSeq downloader did not report final aggregate completion"
+	if grep -Eq "Saving to:|HTTP request sent|Resolving |Connecting to " "$tmp/stdout" "$tmp/stderr"; then
+		fail "RefSeq downloader leaked per-file network chatter"
+	fi
+	pass "RefSeq downloader uses quiet network commands and aggregate progress"
+}
+
 test_refseq_downloader_mocked_assembly_summary() {
 	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-refseq-mocked-test.XXXXXX")"
 	trap 'rm -rf "$tmp"' RETURN
@@ -507,9 +620,9 @@ test_refseq_downloader_mocked_assembly_summary() {
 	cat > "$bindir/wget" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
-if [ "${1:-}" = "-c" ]; then
+while [ "${1:-}" = "-q" ] || [ "${1:-}" = "--quiet" ] || [ "${1:-}" = "-c" ]; do
 	shift
-fi
+done
 if [ "$1" = "-O" ]; then
 	out="$2"
 	url="$3"
@@ -568,9 +681,9 @@ test_refseq_downloader_filters_and_resumes() {
 	cat > "$bindir/wget" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
-if [ "${1:-}" = "-c" ]; then
+while [ "${1:-}" = "-q" ] || [ "${1:-}" = "--quiet" ] || [ "${1:-}" = "-c" ]; do
 	shift
-fi
+done
 if [ "$1" = "-O" ]; then
 	out="$2"
 	url="$3"
@@ -1044,10 +1157,12 @@ test_classify_wrapper_rejects_conflicting_variants
 test_scripts_directory_entrypoint
 test_set_targets_records_absolute_db_paths
 test_set_targets_passes_refseq_download_options
+test_set_targets_defaults_to_parallel_resume_downloads
 test_update_taxonomy_requires_db_directory
 test_refseq_downloader_dry_run_manifest
 test_refseq_downloader_normalizes_ncbi_trailing_slash_paths
 test_refseq_downloader_rejects_malformed_urls_before_download
+test_refseq_downloader_quiet_aggregate_progress
 test_refseq_downloader_mocked_assembly_summary
 test_refseq_downloader_filters_and_resumes
 test_make_metadata_uses_refseq_provenance_taxids

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -426,6 +426,75 @@ test_refseq_downloader_dry_run_manifest() {
 	pass "RefSeq downloader dry-run writes manifest and provenance"
 }
 
+test_refseq_downloader_normalizes_ncbi_trailing_slash_paths() {
+	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-refseq-ncbi-url-test.XXXXXX")"
+	trap 'rm -rf "$tmp"' RETURN
+
+	dbdir="$tmp/db"
+	bindir="$tmp/bin"
+	log="$tmp/wget.log"
+	mkdir -p "$bindir"
+
+	cat > "$bindir/wget" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "-O" ]; then
+	out="$2"
+	url="$3"
+	printf '%s\n' "$url" >> "$CLARK_TEST_WGET_LOG"
+	case "$url" in
+		*/bacteria/assembly_summary.txt)
+			{
+				printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n'
+				printf 'GCF_055383595.1\tna\tna\tna\tna\t111\t111\tMock bacterium\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tASM5538359v1\tNCBI\tna\tna\thttps://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/055/383/595/GCF_055383595.1_ASM5538359v1/\n'
+				printf 'GCF_900128725.1\tna\tna\tna\tna\t222\t222\tMock bacterium 2\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tBCifornacula_v1.0\tNCBI\tna\tna\thttps://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/900/128/725/GCF_900128725.1_BCifornacula_v1.0/\n'
+			} > "$out"
+			;;
+		*/archaea/assembly_summary.txt)
+			printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n' > "$out"
+			;;
+		*)
+			echo "unexpected wget -O URL: $url" >&2
+			exit 1
+			;;
+	esac
+else
+	echo "unexpected sequence download during dry-run: $*" >&2
+	exit 1
+fi
+STUB
+	chmod +x "$bindir/wget"
+
+	PATH="$bindir:$PATH" \
+	CLARK_TEST_WGET_LOG="$log" \
+	CLARK_REFSEQ_STATIC_URLS="$tmp/missing-static-urls.tsv" \
+		"$REPO_DIR/scripts/download_RefSeqDB.sh" --dry-run "$dbdir" bacteria > "$tmp/downloader.out"
+
+	grep -Fq "Selected 2 bacteria RefSeq genome(s)" "$tmp/downloader.out" || fail "RefSeq downloader did not select the NCBI-shaped fixture rows"
+	grep -Fq "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/055/383/595/GCF_055383595.1_ASM5538359v1/GCF_055383595.1_ASM5538359v1_genomic.fna.gz" "$dbdir/.bacteria.download_manifest.tsv" ||
+		fail "RefSeq downloader did not normalize the real NCBI trailing-slash ftp_path shape"
+	if grep -Fq "//_genomic.fna.gz" "$dbdir/.bacteria.download_manifest.tsv"; then
+		fail "RefSeq downloader emitted the broken double-slash empty-basename URL"
+	fi
+	pass "RefSeq downloader normalizes NCBI trailing-slash assembly_summary paths"
+}
+
+test_refseq_downloader_rejects_malformed_urls_before_download() {
+	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-refseq-malformed-url-test.XXXXXX")"
+	trap 'rm -rf "$tmp"' RETURN
+
+	dbdir="$tmp/db"
+	static_urls="$tmp/static-urls.tsv"
+	printf 'plasmid\trefseq_static\thttps://example.org/refseq/GCF_055383595.1_ASM5538359v1//_genomic.fna.gz\n' > "$static_urls"
+
+	if CLARK_REFSEQ_STATIC_URLS="$static_urls" "$REPO_DIR/scripts/download_RefSeqDB.sh" --dry-run "$dbdir" plasmid > "$tmp/stdout" 2> "$tmp/stderr"; then
+		fail "RefSeq downloader accepted a malformed empty-basename URL"
+	fi
+	grep -Fq "generated malformed RefSeq download URL" "$tmp/stderr" ||
+		fail "RefSeq downloader did not explain malformed URL rejection"
+	pass "RefSeq downloader rejects malformed generated URLs before download"
+}
+
 test_refseq_downloader_mocked_assembly_summary() {
 	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-refseq-mocked-test.XXXXXX")"
 	trap 'rm -rf "$tmp"' RETURN
@@ -449,7 +518,7 @@ if [ "$1" = "-O" ]; then
 		*/assembly_summary.txt)
 			{
 				printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n'
-				printf 'GCF_999999999.1\tna\tna\tna\trepresentative genome\t10239\t10239\tMock virus\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2024-01-02\tMockVirus1\tCLARK\tna\tna\thttps://example.org/refseq/GCF_999999999.1_MockVirus1\n'
+				printf 'GCF_999999999.1\tna\tna\tna\trepresentative genome\t10239\t10239\tMock virus\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2024-01-02\tMockVirus1\tCLARK\tna\tna\thttps://example.org/refseq/GCF_999999999.1_MockVirus1/\n'
 				printf 'GCF_000000000.1\tna\tna\tna\trepresentative genome\t10239\t10239\tOld virus\tna\tna\treplaced\tComplete Genome\tMajor\tFull\t2020-01-02\tOldVirus\tCLARK\tna\tna\thttps://example.org/refseq/GCF_000000000.1_OldVirus\n'
 			} > "$out"
 			;;
@@ -477,6 +546,8 @@ STUB
 
 	require_file "$dbdir/.viruses"
 	grep -Fq "GCF_999999999.1_MockVirus1_genomic.fna" "$dbdir/.viruses" || fail "RefSeq downloader did not list decompressed virus FASTA"
+	grep -Fq "https://example.org/refseq/GCF_999999999.1_MockVirus1/GCF_999999999.1_MockVirus1_genomic.fna.gz" "$dbdir/.viruses.download_manifest.tsv" ||
+		fail "RefSeq downloader did not normalize trailing slashes in assembly_summary ftp_path"
 	grep -Fq "GCF_999999999.1" "$dbdir/.viruses.provenance.tsv" || fail "RefSeq downloader did not record assembly accession provenance"
 	grep -Fq "2024-01-02" "$dbdir/.viruses.provenance.tsv" || fail "RefSeq downloader did not preserve assembly source date"
 	grep -Fq "downloaded" "$dbdir/.viruses.download_manifest.tsv" || fail "RefSeq downloader did not record completed downloads"
@@ -508,8 +579,8 @@ if [ "$1" = "-O" ]; then
 		*/bacteria/assembly_summary.txt)
 			{
 				printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n'
-				printf 'GCF_111111111.1\tna\tna\tna\trepresentative genome\t111\t111\tExisting bacterium\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2025-01-01\tExisting\tCLARK\tna\tna\thttps://example.org/refseq/GCF_111111111.1_Existing\n'
-				printf 'GCF_222222222.1\tna\tna\tna\trepresentative genome\t222\t222\tNew bacterium\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2025-01-02\tNew\tCLARK\tna\tna\thttps://example.org/refseq/GCF_222222222.1_New\n'
+				printf 'GCF_111111111.1\tna\tna\tna\trepresentative genome\t111\t111\tExisting bacterium\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2025-01-01\tExisting\tCLARK\tna\tna\thttps://example.org/refseq/GCF_111111111.1_Existing/\n'
+				printf 'GCF_222222222.1\tna\tna\tna\trepresentative genome\t222\t222\tNew bacterium\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2025-01-02\tNew\tCLARK\tna\tna\thttps://example.org/refseq/GCF_222222222.1_New/\n'
 				printf 'GCF_333333333.1\tna\tna\tna\tna\t333\t333\tUnselected bacterium\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2025-01-03\tUnselected\tCLARK\tna\tna\thttps://example.org/refseq/GCF_333333333.1_Unselected\n'
 				printf 'GCF_444444444.1\tna\tna\tna\trepresentative genome\t444\t444\tDraft bacterium\tna\tna\tlatest\tScaffold\tMajor\tFull\t2025-01-04\tDraft\tCLARK\tna\tna\thttps://example.org/refseq/GCF_444444444.1_Draft\n'
 			} > "$out"
@@ -975,6 +1046,8 @@ test_set_targets_records_absolute_db_paths
 test_set_targets_passes_refseq_download_options
 test_update_taxonomy_requires_db_directory
 test_refseq_downloader_dry_run_manifest
+test_refseq_downloader_normalizes_ncbi_trailing_slash_paths
+test_refseq_downloader_rejects_malformed_urls_before_download
 test_refseq_downloader_mocked_assembly_summary
 test_refseq_downloader_filters_and_resumes
 test_make_metadata_uses_refseq_provenance_taxids

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -744,6 +744,151 @@ STUB
 	pass "RefSeq downloader retries transient parallel failures and finalizes archives"
 }
 
+test_refseq_downloader_defers_retry_until_after_first_pass() {
+	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-refseq-deferred-retry-test.XXXXXX")"
+	trap 'rm -rf "$tmp"' RETURN
+
+	dbdir="$tmp/db"
+	bindir="$tmp/bin"
+	state="$tmp/state"
+	mkdir -p "$bindir" "$state"
+
+	cat > "$bindir/wget" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+out=""
+url=""
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		-q|--quiet|-c)
+			shift
+			;;
+		-O)
+			out="$2"
+			shift 2
+			;;
+		*)
+			url="$1"
+			shift
+			;;
+	esac
+done
+case "$url" in
+	*/viral/assembly_summary.txt)
+		{
+			printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n'
+			for i in 1 2 3 4 5; do
+				printf 'GCF_300000%03d.1\tna\tna\tna\trepresentative genome\t10239\t10239\tDeferred virus %d\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tDeferred%d\tCLARK\tna\tna\thttps://example.org/refseq/GCF_300000%03d.1_Deferred%d/\n' "$i" "$i" "$i" "$i" "$i"
+			done
+		} > "$out"
+		;;
+	*_genomic.fna.gz)
+		base="${url##*/}"
+		case "$base" in
+			GCF_300000001.1_Deferred1_genomic.fna.gz)
+				if [ ! -d "$CLARK_TEST_STATE/first-pass-finished" ]; then
+					printf 'temporary NCBI outage for %s\n' "$base" > "$out"
+					exit 1
+				fi
+				;;
+			GCF_300000005.1_Deferred5_genomic.fna.gz)
+				mkdir "$CLARK_TEST_STATE/first-pass-finished" 2>/dev/null || true
+				;;
+		esac
+		printf '>deferred-virus\nACGT\n' | gzip > "$out"
+		;;
+	*)
+		echo "unexpected URL: $url" >&2
+		exit 1
+		;;
+esac
+STUB
+	chmod +x "$bindir/wget"
+
+	PATH="$bindir:$PATH" \
+	CLARK_TEST_STATE="$state" \
+	CLARK_REFSEQ_STATIC_URLS="$tmp/missing-static-urls.tsv" \
+	CLARK_REFSEQ_RETRY_DELAY=0 \
+		"$REPO_DIR/scripts/download_RefSeqDB.sh" --threads 1 "$dbdir" viruses > "$tmp/stdout" 2> "$tmp/stderr"
+
+	grep -Fq "Retrying 1 deferred RefSeq download(s)" "$tmp/stdout" ||
+		fail "RefSeq downloader did not defer failed URLs for a later retry pass"
+	count=$(find "$dbdir/Viruses" -type f -name '*.fna' | wc -l | tr -d ' ')
+	[ "$count" = "5" ] || fail "RefSeq downloader did not complete all files after deferred retry"
+	grep -Fq "deferred" "$dbdir/.viruses.download_manifest.tsv" ||
+		fail "RefSeq downloader did not record the deferred first-pass status"
+	grep -Fq "GCF_300000001.1_Deferred1_genomic.fna" "$dbdir/.viruses" ||
+		fail "RefSeq downloader did not list the deferred and later downloaded FASTA"
+	pass "RefSeq downloader retries deferred URLs after the first pass"
+}
+
+test_refseq_downloader_fails_when_deferred_downloads_remain() {
+	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-refseq-permanent-failure-test.XXXXXX")"
+	trap 'rm -rf "$tmp"' RETURN
+
+	dbdir="$tmp/db"
+	bindir="$tmp/bin"
+	mkdir -p "$bindir"
+
+	cat > "$bindir/wget" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+out=""
+url=""
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		-q|--quiet|-c)
+			shift
+			;;
+		-O)
+			out="$2"
+			shift 2
+			;;
+		*)
+			url="$1"
+			shift
+			;;
+	esac
+done
+case "$url" in
+	*/viral/assembly_summary.txt)
+		{
+			printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n'
+			for i in 1 2 3 4; do
+				printf 'GCF_400000%03d.1\tna\tna\tna\trepresentative genome\t10239\t10239\tFailure virus %d\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tFailure%d\tCLARK\tna\tna\thttps://example.org/refseq/GCF_400000%03d.1_Failure%d/\n' "$i" "$i" "$i" "$i" "$i"
+			done
+		} > "$out"
+		;;
+	*GCF_400000002.1_Failure2_genomic.fna.gz)
+		printf 'permanent transfer failure\n' > "$out"
+		exit 1
+		;;
+	*_genomic.fna.gz)
+		printf '>failure-virus\nACGT\n' | gzip > "$out"
+		;;
+	*)
+		echo "unexpected URL: $url" >&2
+		exit 1
+		;;
+esac
+STUB
+	chmod +x "$bindir/wget"
+
+	if PATH="$bindir:$PATH" \
+		CLARK_REFSEQ_STATIC_URLS="$tmp/missing-static-urls.tsv" \
+		CLARK_REFSEQ_RETRY_DELAY=0 \
+			"$REPO_DIR/scripts/download_RefSeqDB.sh" --threads 4 "$dbdir" viruses > "$tmp/stdout" 2> "$tmp/stderr"; then
+		fail "RefSeq downloader reported success despite a permanent deferred failure"
+	fi
+
+	grep -Fq "Failed to download 1 RefSeq genome file(s) after deferred retries" "$tmp/stderr" ||
+		fail "RefSeq downloader did not summarize permanent deferred failures"
+	[ ! -e "$dbdir/.viruses" ] || fail "RefSeq downloader wrote a success marker after an incomplete download"
+	grep -Fq "failed" "$dbdir/.viruses.download_manifest.tsv" ||
+		fail "RefSeq downloader did not record failed final status in the manifest"
+	pass "RefSeq downloader fails loudly when deferred downloads remain incomplete"
+}
+
 test_refseq_downloader_reports_early_parallel_progress() {
 	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-refseq-progress-refresh-test.XXXXXX")"
 	trap 'rm -rf "$tmp"' RETURN
@@ -1357,6 +1502,8 @@ test_refseq_downloader_normalizes_ncbi_trailing_slash_paths
 test_refseq_downloader_rejects_malformed_urls_before_download
 test_refseq_downloader_quiet_aggregate_progress
 test_refseq_downloader_retries_parallel_transient_failures
+test_refseq_downloader_defers_retry_until_after_first_pass
+test_refseq_downloader_fails_when_deferred_downloads_remain
 test_refseq_downloader_reports_early_parallel_progress
 test_refseq_downloader_success_matrix
 test_refseq_downloader_filters_and_resumes

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -72,7 +72,7 @@ test_version_binaries() {
 	for binary in CLARK CLARK-l CLARK-S; do
 		version="$("$REPO_DIR/exe/$binary" --version)"
 		case "$version" in
-			*"Version: 1.4.3.0-a"*) ;;
+			*"Version: 1.4.4.0-a"*) ;;
 			*) fail "unexpected version output from $binary: $version" ;;
 		esac
 	done


### PR DESCRIPTION
## WHAT
This PR prepares CLARK v1.4.4.0-a and improves the RefSeq database setup workflow used by scripts/set_targets.sh.
Main changes:
- Speeds up RefSeq genome downloads for database creation.
- Adds parallel download support with safer default behavior.
- Enables resumable downloads by default.
- Reduces noisy per-file wget output and reports cleaner overall progress.
- Hardens RefSeq URL construction to avoid malformed NCBI download URLs.
- Improves .part handling for interrupted or failed downloads.
- Updates release metadata in CHANGELOG, README, README_FULL, and src/parameters*.
- Consolidates downloader tests and adds mocked success coverage for:viruses, plasmid,plastid,protozoa

## WHY
Users reported that ./scripts/set_targets.sh could take too long, especially when preparing bacterial databases, because the previous workflow downloaded large numbers of RefSeq files sequentially and printed excessive network output.
This release improves the user experience for researchers who are not bioinformatics experts by making database setup faster, quieter, more resumable, and better tested.

## HOW
The downloader logic was updated to:
Use multiple download workers by default.
Resume interrupted downloads by default.
Build NCBI RefSeq genome URLs from assembly metadata more carefully.
Keep temporary .part files isolated until a download completes.
Avoid leaving stale partial files after failed downloads.
Emit concise progress information instead of overwhelming the terminal with every network request.
Preserve existing CLARK database setup behavior while improving reliability and usability.

## TESTS
Passing checks include:
bash -n tests/run_tests.sh
make all unit-tests
make test
make coverageCurrent coverage: 22.63%

./exe/CLARK --version
./exe/CLARK-l --version
./exe/CLARK-S --version
Additional downloader verification:
Mocked RefSeq downloader tests cover viruses, plasmid, plastid, and protozoa.
Tests verify manifest/provenance output.
Tests verify no leftover .part files remain after successful mocked downloads.
Tests verify quiet download behavior.
A small live NCBI smoke test was run successfully with parallel downloads.

## SECURITY CONCERNS
No new external dependencies were added.
This PR continues to rely on NCBI HTTPS endpoints for RefSeq metadata and genome downloads. The downloader now avoids generating legacy download.sh scripts during tested paths and improves handling of temporary download files.

## OTHERS / FOLLOW-UP WORK
This release improves the existing shell-based downloader, but it does not fully replace it.
Recommended next release work:
Replace the shell download engine with a Python 3 standard-library downloader.
Add manifest-driven downloads.
Use a bounded worker pool.
Add retry with exponential backoff.
Add gzip validation.
Add checksum validation when available.
Add resumable state files.
Separate progress display from detailed logs.
Optionally support rsync --files-from acceleration.