### PR TITLE
v1.4.5.0: Improved RefSeq reference downloads

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+06/21/2026  Version 1.4.5.0-a:
+		Replaced the RefSeq sequence-transfer loop with a Python 3 standard-library downloader.
+		Added bounded parallel downloads, resumable .part files, gzip validation, deferred retry, aggregate progress, and failure reports.
+		Preserved existing RefSeq selection and provenance behavior for bacteria, viruses, plasmid, plastid, protozoa, and related databases.
+		Added regression tests for successful downloads, transient failures, deferred retries, permanent failures, resume behavior, and supported database categories.
 06/21/2026  Version 1.4.4.0-a:
 		Improved RefSeq database setup for large downloads, especially bacteria.
 		RefSeq downloads now use parallel resumable transfers by default and support filters for smaller exploratory databases.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ CLARK is distributed under the GNU General Public License (GPL) v3. It is free s
 
 ## Releases
 
+### Version 1.4.5 (June 21, 2026)
+- Replaced RefSeq sequence transfers with a Python 3 standard-library downloader.
+- Added bounded parallel downloads, resumable `.part` files, gzip validation, deferred retry, aggregate progress, and failure reports.
+- Preserved existing RefSeq selection and provenance behavior for supported database categories.
+- Added regression tests for successful downloads, transient failures, deferred retries, permanent failures, resume behavior, and supported database categories.
+
 ### Version 1.4.4 (June 21, 2026)
 - Improved large RefSeq database setup, especially for bacteria, with parallel resumable downloads by default.
 - Added RefSeq category and assembly-level filters for smaller exploratory databases.

--- a/README_FULL.md
+++ b/README_FULL.md
@@ -1296,6 +1296,8 @@ In the default or express mode, the results format is the following for each lin
 
 ## VERSIONS
 
+Version 1.4.5.0-a	June 21, 2026.
+
 Version 1.4.4.0-a	June 21, 2026.
 
 Version 1.4.3.0-a	June 21, 2026.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -19,7 +19,7 @@ make coverage
 
 ## Current Coverage
 
-The suite currently contains 26 regression tests. It verifies:
+The suite currently contains 43 regression tests. It verifies:
 
 - all required executables are created by the build
 - `CLARK`, `CLARK-l`, and `CLARK-S` respond to `--version`
@@ -32,9 +32,15 @@ The suite currently contains 26 regression tests. It verifies:
 - conflicting `--light` and `--spaced` options are rejected
 - direct `scripts/` entrypoints resolve the repository root correctly
 - `scripts/set_targets.sh` records absolute database paths when run from another working directory
+- `scripts/set_targets.sh` forwards RefSeq download options and defaults to parallel resumable downloads
 - `scripts/updateTaxonomy.sh` reports missing database configuration clearly
 - `scripts/download_RefSeqDB.sh --dry-run` writes RefSeq manifest and provenance files
 - `scripts/download_RefSeqDB.sh` can process a mocked NCBI assembly summary without live network access
+- `scripts/download_RefSeqDB.sh` normalizes NCBI assembly-summary paths to HTTPS sequence URLs
+- `scripts/download_RefSeqDB.sh` keeps network output quiet while reporting aggregate progress
+- `scripts/download_RefSeqDB.sh` retries transient and deferred failures, then reports remaining failures clearly
+- `scripts/download_RefSeqDB.sh` completes mocked viruses, plasmid, plastid, and protozoa downloads
+- RefSeq provenance taxids are used when metadata is generated from downloaded assemblies
 - README command examples use `scripts/` without stale root-relative script paths
 - `getTargetsDef` emits expected target definitions for a tiny synthetic input
 - `getAccssnTaxID` maps accession IDs and handles unmapped FASTA records
@@ -61,10 +67,10 @@ below the required minimum.
 
 Current coverage from `make coverage`:
 
-- covered executable C++ lines: 915
-- total executable C++ lines: 5,611
-- line coverage: 16.31%
-- required minimum: 10.00%
+- covered executable C++ lines: 1,277
+- total executable C++ lines: 5,642
+- line coverage: 22.63%
+- required minimum: 20.00%
 
 ## Coverage Limitations
 

--- a/scripts/download_RefSeqDB.sh
+++ b/scripts/download_RefSeqDB.sh
@@ -265,6 +265,7 @@ download_assembly_source() {
 					next
 				}
 				ftp_path = $20
+				sub(/^ftp:\/\/ftp\.ncbi\.nlm\.nih\.gov/, "https://ftp.ncbi.nlm.nih.gov", ftp_path)
 				sub(/\/+$/, "", ftp_path)
 				n = split(ftp_path, path_parts, "/")
 				if (ftp_path == "" || path_parts[n] == "") {

--- a/scripts/download_RefSeqDB.sh
+++ b/scripts/download_RefSeqDB.sh
@@ -51,6 +51,7 @@ FIRST_PASS_ATTEMPTS=${CLARK_REFSEQ_FIRST_PASS_ATTEMPTS:-3}
 RETRY_DELAY=${CLARK_REFSEQ_RETRY_DELAY:-2}
 REFSEQ_CATEGORY=${CLARK_REFSEQ_CATEGORY:-all}
 ASSEMBLY_LEVEL=${CLARK_REFSEQ_ASSEMBLY_LEVEL:-Complete Genome}
+PYTHON_CMD=${CLARK_PYTHON:-python3}
 
 while [ "$#" -gt 0 ]; do
 	case "$1" in
@@ -238,80 +239,6 @@ fetch_to_file() {
 	record_manifest "metadata" "$source" "$url" "$output" "downloaded"
 }
 
-valid_gzip_archive() {
-	[ -s "$1" ] || return 1
-	gzip -t "$1" >/dev/null 2>&1
-}
-
-run_sequence_download_once() {
-	url="$1"
-	partial="$2"
-
-	if command -v wget >/dev/null 2>&1; then
-		if [ "$RESUME" = "1" ] && [ -s "$partial" ]; then
-			wget -q -c -O "$partial" "$url"
-		else
-			wget -q -O "$partial" "$url"
-		fi
-	elif command -v curl >/dev/null 2>&1; then
-		if [ "$RESUME" = "1" ] && [ -s "$partial" ]; then
-			curl -fsSL --retry 3 -C - -o "$partial" "$url"
-		else
-			curl -fsSL --retry 3 -o "$partial" "$url"
-		fi
-	else
-		die "neither wget nor curl is available"
-	fi
-}
-
-fetch_url_to_status() {
-	url="$1"
-	source="$2"
-	status_file="$3"
-	max_attempts="$4"
-	failure_status="$5"
-	output=${url##*/}
-
-	if [ -s "$output" ]; then
-		if ! valid_gzip_archive "$output"; then
-			rm -f "$output"
-		else
-			record_manifest_line "$status_file" "download" "$source" "$url" "$(pwd)/$output" "skipped-existing"
-			return 0
-		fi
-	fi
-	if [ "${output%.gz}" != "$output" ] && [ -s "${output%.gz}" ]; then
-		record_manifest_line "$status_file" "download" "$source" "$url" "$(pwd)/${output%.gz}" "skipped-existing"
-		return 0
-	fi
-
-	partial="$output.part"
-	if [ "$RESUME" != "1" ]; then
-		rm -f "$partial"
-	fi
-
-	attempt=1
-	while [ "$attempt" -le "$max_attempts" ]; do
-		if run_sequence_download_once "$url" "$partial"; then
-			:
-		fi
-		if valid_gzip_archive "$partial"; then
-			mv "$partial" "$output"
-			record_manifest_line "$status_file" "download" "$source" "$url" "$(pwd)/$output" "downloaded"
-			return 0
-		fi
-		rm -f "$partial"
-		if [ "$attempt" -lt "$max_attempts" ] && [ "$RETRY_DELAY" -gt 0 ]; then
-			sleep $((RETRY_DELAY * attempt))
-		fi
-		attempt=$((attempt + 1))
-	done
-
-	rm -f "$partial"
-	record_manifest_line "$status_file" "download" "$source" "$url" "$(pwd)/$output" "$failure_status"
-	return 0
-}
-
 download_assembly_source() {
 	source="$1"
 	summary_url="https://ftp.ncbi.nlm.nih.gov/genomes/refseq/$source/assembly_summary.txt"
@@ -414,92 +341,6 @@ validate_download_list() {
 	' "$DOWNLOAD_LIST" || die "generated malformed RefSeq download URL(s); aborting before download"
 }
 
-report_download_progress() {
-	label="$1"
-	completed="$2"
-	total="$3"
-	if [ "$total" -eq 0 ]; then
-		message="$label: 0/0 files complete (100%)."
-		if [ -t 1 ]; then printf '\r%s\n' "$message"; else echo "$message"; fi
-		return 0
-	fi
-	percent=$((completed * 100 / total))
-	message="$label: $completed/$total files complete ($percent%)."
-	if [ -t 1 ]; then
-		if [ "$completed" -ge "$total" ]; then
-			printf '\r%s\n' "$message"
-		else
-			printf '\r%s' "$message"
-		fi
-	else
-		echo "$message"
-	fi
-}
-
-run_download_pass() {
-	list_file="$1"
-	status_prefix="$2"
-	max_attempts="$3"
-	failure_status="$4"
-	progress_label="$5"
-	total=$(wc -l < "$list_file" | tr -d ' ')
-
-	[ "$total" -gt 0 ] || return 0
-
-	job_count=0
-	job_index=0
-	completed=0
-	progress_step=$((total / 100))
-	[ "$progress_step" -gt 0 ] || progress_step=1
-	[ "$progress_step" -le 100 ] || progress_step=100
-	next_report="$progress_step"
-	report_download_progress "$progress_label" 0 "$total"
-	while IFS='	' read -r source genome_url || [ -n "$genome_url" ]; do
-		[ -n "$genome_url" ] || continue
-		job_index=$((job_index + 1))
-		fetch_url_to_status "$genome_url" "$source" "$status_dir/$status_prefix.$job_index.status.tsv" "$max_attempts" "$failure_status" &
-		job_count=$((job_count + 1))
-		if [ "$job_count" -ge "$THREADS" ]; then
-			wait
-			completed=$((completed + job_count))
-			if [ -t 1 ] || [ "$completed" -ge "$next_report" ] || [ "$completed" -ge "$total" ]; then
-				report_download_progress "$progress_label" "$completed" "$total"
-				while [ "$next_report" -le "$completed" ]; do
-					next_report=$((next_report + progress_step))
-				done
-			fi
-			job_count=0
-		fi
-	done < "$list_file"
-	if [ "$job_count" -gt 0 ]; then
-		wait
-		completed=$((completed + job_count))
-		report_download_progress "$progress_label" "$completed" "$total"
-	fi
-}
-
-collect_deferred_downloads() {
-	find "$status_dir" -type f -name 'initial.*.status.tsv' -exec awk -F '\t' '
-		$7 == "deferred" { print $4 "\t" $5 }
-	' {} + > "$retry_list"
-}
-
-report_remaining_failures() {
-	find "$status_dir" -type f -name '*.status.tsv' -exec awk -F '\t' '
-		$7 == "failed" { print $4 "\t" $5 }
-	' {} + > "$failed_list"
-	[ -s "$failed_list" ] || return 0
-
-	failed_count=$(wc -l < "$failed_list" | tr -d ' ')
-	echo "Failed to download $failed_count RefSeq genome file(s) after deferred retries." >&2
-	echo "First failed URLs:" >&2
-	sed -n '1,20p' "$failed_list" | while IFS='	' read -r failed_source failed_url || [ -n "$failed_url" ]; do
-		[ -n "$failed_url" ] || continue
-		echo "  [$failed_source] $failed_url" >&2
-	done
-	die "RefSeq download incomplete; rerun the same command to resume and retry failed files"
-}
-
 download_url_list() {
 	validate_download_list
 	total=$(wc -l < "$DOWNLOAD_LIST" | tr -d ' ')
@@ -513,25 +354,22 @@ download_url_list() {
 		return 0
 	fi
 
-	status_dir="$DBDR/.$DB.download-status.$$"
-	rm -rf "$status_dir"
-	mkdir -p "$status_dir"
-	retry_list="$status_dir/deferred.urls.tsv"
-	failed_list="$status_dir/failed.urls.tsv"
-
-	run_download_pass "$DOWNLOAD_LIST" initial "$FIRST_PASS_ATTEMPTS" deferred "RefSeq download progress"
-	collect_deferred_downloads
-	if [ -s "$retry_list" ]; then
-		deferred_count=$(wc -l < "$retry_list" | tr -d ' ')
-		echo "Retrying $deferred_count deferred RefSeq download(s) after the first pass."
-		run_download_pass "$retry_list" retry "$DOWNLOAD_ATTEMPTS" failed "RefSeq deferred retry progress"
-	fi
-
-	if [ -n "$(find "$status_dir" -type f -print -quit)" ]; then
-		find "$status_dir" -type f -name '*.status.tsv' -exec cat {} + >> "$MANIFEST"
-	fi
-	report_remaining_failures
-	rm -rf "$status_dir"
+	command -v "$PYTHON_CMD" >/dev/null 2>&1 || die "Python 3 is required for RefSeq downloads"
+	rm -f "$DBDR/.$DB.download_state.jsonl" "$DBDR/.$DB.download.log" "$DBDR/.$DB.failed_downloads.tsv"
+	"$PYTHON_CMD" "$DIR/scripts/refseq_downloader.py" \
+		--download-list "$DOWNLOAD_LIST" \
+		--manifest "$MANIFEST" \
+		--database "$DB" \
+		--data-dir "$DATA_DIR" \
+		--timestamp "$RUN_STARTED_UTC" \
+		--state "$DBDR/.$DB.download_state.jsonl" \
+		--log "$DBDR/.$DB.download.log" \
+		--failed-list "$DBDR/.$DB.failed_downloads.tsv" \
+		--threads "$THREADS" \
+		--resume "$RESUME" \
+		--attempts "$DOWNLOAD_ATTEMPTS" \
+		--first-pass-attempts "$FIRST_PASS_ATTEMPTS" \
+		--retry-delay "$RETRY_DELAY"
 }
 
 if [ "$DRY_RUN" != "1" ] && [ -s "$MARKER" ]; then

--- a/scripts/refseq_downloader.py
+++ b/scripts/refseq_downloader.py
@@ -195,7 +195,12 @@ def fetch_entry(entry, data_dir, max_attempts, failure_status, retry_delay, resu
 
 def print_progress(label, completed, total):
     percent = 100 if total == 0 else int(completed * 100 / total)
-    print("%s: %d/%d files complete (%d%%)." % (label, completed, total, percent), flush=True)
+    message = "%s: %d/%d files complete (%d%%)." % (label, completed, total, percent)
+    if sys.stdout.isatty():
+        sys.stdout.write("\r%s%s" % (message, "\n" if completed >= total else ""))
+        sys.stdout.flush()
+    else:
+        print(message, flush=True)
 
 
 def run_pass(entries, label, threads, max_attempts, failure_status, retry_delay, resume, data_dir):

--- a/scripts/refseq_downloader.py
+++ b/scripts/refseq_downloader.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Manifest-driven RefSeq downloader for CLARK."""
+
+import argparse
+import concurrent.futures
+import gzip
+import hashlib
+import json
+import logging
+import os
+from pathlib import Path
+import random
+import shutil
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+USER_AGENT = "CLARK-refseq-downloader/1.4.5"
+GZIP_ERRORS = (EOFError, OSError) + ((gzip.BadGzipFile,) if hasattr(gzip, "BadGzipFile") else ())
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Download CLARK RefSeq files from a manifest.")
+    parser.add_argument("--download-list", required=True)
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--database", required=True)
+    parser.add_argument("--data-dir", required=True)
+    parser.add_argument("--timestamp", required=True)
+    parser.add_argument("--state", required=True)
+    parser.add_argument("--log", required=True)
+    parser.add_argument("--failed-list", required=True)
+    parser.add_argument("--threads", type=int, default=8)
+    parser.add_argument("--resume", type=int, choices=(0, 1), default=1)
+    parser.add_argument("--attempts", type=int, default=5)
+    parser.add_argument("--first-pass-attempts", type=int, default=3)
+    parser.add_argument("--retry-delay", type=int, default=2)
+    return parser.parse_args()
+
+
+def setup_logging(path):
+    logging.basicConfig(
+        filename=path,
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+
+def read_download_list(path):
+    entries = []
+    with open(path, "r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, 1):
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            fields = line.split("\t")
+            if len(fields) < 2 or not fields[0] or not fields[1]:
+                raise ValueError("malformed download entry at line %d" % line_number)
+            checksum = fields[2] if len(fields) > 2 and fields[2] else ""
+            entries.append(
+                {
+                    "index": len(entries) + 1,
+                    "source": fields[0],
+                    "url": fields[1],
+                    "checksum": checksum,
+                }
+            )
+    return entries
+
+
+def filename_from_url(url):
+    path = urllib.parse.urlsplit(url).path
+    name = os.path.basename(path)
+    if not name:
+        raise ValueError("download URL has no filename: %s" % url)
+    return name
+
+
+def gzip_is_valid(path):
+    if not path.exists() or path.stat().st_size == 0:
+        return False
+    try:
+        with gzip.open(path, "rb") as handle:
+            while handle.read(1024 * 1024):
+                pass
+        return True
+    except GZIP_ERRORS:
+        return False
+
+
+def md5sum(path):
+    digest = hashlib.md5()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def checksum_is_valid(path, expected):
+    if not expected:
+        return True
+    return md5sum(path).lower() == expected.lower()
+
+
+def manifest_row(timestamp, database, action, source, url, local_path, status):
+    return "\t".join([timestamp, database, action, source, url, local_path, status])
+
+
+def state_record(entry, output_path, status, attempt_count, error=""):
+    return {
+        "index": entry["index"],
+        "source": entry["source"],
+        "url": entry["url"],
+        "local_path": str(output_path),
+        "status": status,
+        "attempts": attempt_count,
+        "error": error,
+        "time_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+
+def append_jsonl(path, records):
+    with open(path, "a", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def download_once(url, partial_path, resume):
+    headers = {"User-Agent": USER_AGENT}
+    mode = "wb"
+    existing_size = partial_path.stat().st_size if partial_path.exists() else 0
+    scheme = urllib.parse.urlsplit(url).scheme
+
+    if resume and existing_size > 0 and scheme in ("http", "https"):
+        headers["Range"] = "bytes=%d-" % existing_size
+        mode = "ab"
+
+    request = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(request, timeout=120) as response:
+        status = getattr(response, "status", None)
+        if mode == "ab" and status != 206:
+            mode = "wb"
+        with open(partial_path, mode) as output:
+            shutil.copyfileobj(response, output, length=1024 * 1024)
+
+
+def fetch_entry(entry, data_dir, max_attempts, failure_status, retry_delay, resume):
+    url = entry["url"]
+    source = entry["source"]
+    output = data_dir / filename_from_url(url)
+    decompressed = data_dir / output.name[:-3] if output.name.endswith(".gz") else None
+
+    if output.exists():
+        if gzip_is_valid(output) and checksum_is_valid(output, entry["checksum"]):
+            row = manifest_row("", "", "download", source, url, str(output), "skipped-existing")
+            return {"entry": entry, "status": "skipped-existing", "row": row, "path": output, "attempts": 0}
+        output.unlink()
+
+    if decompressed is not None and decompressed.exists() and decompressed.stat().st_size > 0:
+        row = manifest_row("", "", "download", source, url, str(decompressed), "skipped-existing")
+        return {"entry": entry, "status": "skipped-existing", "row": row, "path": decompressed, "attempts": 0}
+
+    partial = data_dir / (output.name + ".part")
+    if not resume and partial.exists():
+        partial.unlink()
+
+    last_error = ""
+    for attempt in range(1, max_attempts + 1):
+        try:
+            download_once(url, partial, resume)
+            if gzip_is_valid(partial) and checksum_is_valid(partial, entry["checksum"]):
+                partial.replace(output)
+                row = manifest_row("", "", "download", source, url, str(output), "downloaded")
+                return {"entry": entry, "status": "downloaded", "row": row, "path": output, "attempts": attempt}
+            last_error = "downloaded file failed gzip or checksum validation"
+        except (OSError, urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as exc:
+            last_error = str(exc)
+        if partial.exists():
+            partial.unlink()
+        if attempt < max_attempts and retry_delay > 0:
+            time.sleep(retry_delay * attempt + random.uniform(0, 0.25))
+
+    row = manifest_row("", "", "download", source, url, str(output), failure_status)
+    return {
+        "entry": entry,
+        "status": failure_status,
+        "row": row,
+        "path": output,
+        "attempts": max_attempts,
+        "error": last_error,
+    }
+
+
+def print_progress(label, completed, total):
+    percent = 100 if total == 0 else int(completed * 100 / total)
+    print("%s: %d/%d files complete (%d%%)." % (label, completed, total, percent), flush=True)
+
+
+def run_pass(entries, label, threads, max_attempts, failure_status, retry_delay, resume, data_dir):
+    if not entries:
+        return []
+
+    results = []
+    completed = 0
+    total = len(entries)
+    progress_step = max(1, min(total // 100, 100))
+    next_report = progress_step
+    print_progress(label, 0, total)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=threads) as pool:
+        futures = [
+            pool.submit(fetch_entry, entry, data_dir, max_attempts, failure_status, retry_delay, resume)
+            for entry in entries
+        ]
+        for future in concurrent.futures.as_completed(futures):
+            result = future.result()
+            results.append(result)
+            completed += 1
+            if completed >= next_report or completed == total:
+                print_progress(label, completed, total)
+                while next_report <= completed:
+                    next_report += progress_step
+
+    results.sort(key=lambda item: item["entry"]["index"])
+    return results
+
+
+def write_manifest_rows(path, rows, timestamp, database):
+    with open(path, "a", encoding="utf-8") as handle:
+        for row in rows:
+            fields = row.split("\t")
+            fields[0] = timestamp
+            fields[1] = database
+            handle.write("\t".join(fields) + "\n")
+
+
+def write_failed_list(path, failures):
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write("source\turl\tlocal_path\tattempts\terror\n")
+        for item in failures:
+            handle.write(
+                "%s\t%s\t%s\t%s\t%s\n"
+                % (
+                    item["entry"]["source"],
+                    item["entry"]["url"],
+                    item["path"],
+                    item["attempts"],
+                    item.get("error", ""),
+                )
+            )
+
+
+def main():
+    args = parse_args()
+    if args.threads <= 0:
+        raise SystemExit("--threads must be a positive integer")
+    if args.attempts <= 0 or args.first_pass_attempts <= 0:
+        raise SystemExit("attempt counts must be positive integers")
+
+    data_dir = Path(args.data_dir)
+    data_dir.mkdir(parents=True, exist_ok=True)
+    setup_logging(args.log)
+    entries = read_download_list(args.download_list)
+    threads = min(args.threads, max(1, len(entries)))
+
+    logging.info("Starting RefSeq download: database=%s files=%d threads=%d", args.database, len(entries), threads)
+    first_results = run_pass(
+        entries,
+        "RefSeq download progress",
+        threads,
+        args.first_pass_attempts,
+        "deferred",
+        args.retry_delay,
+        bool(args.resume),
+        data_dir,
+    )
+    deferred = [item["entry"] for item in first_results if item["status"] == "deferred"]
+    retry_results = []
+    if deferred:
+        print("Retrying %d deferred RefSeq download(s) after the first pass." % len(deferred), flush=True)
+        retry_results = run_pass(
+            deferred,
+            "RefSeq deferred retry progress",
+            threads,
+            args.attempts,
+            "failed",
+            args.retry_delay,
+            bool(args.resume),
+            data_dir,
+        )
+
+    all_results = first_results + retry_results
+    append_jsonl(
+        args.state,
+        [state_record(item["entry"], item["path"], item["status"], item["attempts"], item.get("error", "")) for item in all_results],
+    )
+    write_manifest_rows(args.manifest, [item["row"] for item in all_results], args.timestamp, args.database)
+
+    failures = [item for item in all_results if item["status"] == "failed"]
+    if failures:
+        write_failed_list(args.failed_list, failures)
+        print("Failed to download %d RefSeq genome file(s) after deferred retries." % len(failures), file=sys.stderr)
+        print("First failed URLs:", file=sys.stderr)
+        for item in failures[:20]:
+            print("  [%s] %s" % (item["entry"]["source"], item["entry"]["url"]), file=sys.stderr)
+        return 1
+
+    logging.info("Finished RefSeq download: database=%s files=%d", args.database, len(entries))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/parameters.hh
+++ b/src/parameters.hh
@@ -30,7 +30,7 @@
 #ifndef PARAMETERS_HH
 #define PARAMETERS_HH
 
-#define VERSION "1.4.4.0-a"
+#define VERSION "1.4.5.0-a"
 
 #define SB              4       
 #define DBCTRESH	4

--- a/src/parameters_hh
+++ b/src/parameters_hh
@@ -30,7 +30,7 @@
 #ifndef PARAMETERS_HH
 #define PARAMETERS_HH
 
-#define VERSION "1.4.4.0-a"
+#define VERSION "1.4.5.0-a"
 
 #define SB              4       
 #define DBCTRESH        4

--- a/src/parameters_shh
+++ b/src/parameters_shh
@@ -30,7 +30,7 @@
 #ifndef PARAMETERS_HH
 #define PARAMETERS_HH
 
-#define VERSION "1.4.4.0-a"
+#define VERSION "1.4.5.0-a"
 
 #define SB              4       
 #define DBCTRESH	8

--- a/tests/coverage_report.sh
+++ b/tests/coverage_report.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 REPO_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
 COVERAGE_DIR="$REPO_DIR/build/coverage"
 GCOV_OUT="$COVERAGE_DIR/gcov.out"
-MIN_COVERAGE="${COVERAGE_MIN:-10}"
+MIN_COVERAGE="${COVERAGE_MIN:-20}"
 
 if [ -z "${COVERAGE_CXXFLAGS+x}" ]; then
 	COVERAGE_CXXFLAGS="-O0 -g --coverage"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -635,7 +635,7 @@ if [ "$1" = "-O" ]; then
 			{
 				printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n'
 				printf 'GCF_055383595.1\tna\tna\tna\tna\t111\t111\tMock bacterium\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tASM5538359v1\tNCBI\tna\tna\thttps://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/055/383/595/GCF_055383595.1_ASM5538359v1/\n'
-				printf 'GCF_900128725.1\tna\tna\tna\tna\t222\t222\tMock bacterium 2\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tBCifornacula_v1.0\tNCBI\tna\tna\thttps://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/900/128/725/GCF_900128725.1_BCifornacula_v1.0/\n'
+				printf 'GCF_900128725.1\tna\tna\tna\tna\t222\t222\tMock bacterium 2\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tBCifornacula_v1.0\tNCBI\tna\tna\tftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/900/128/725/GCF_900128725.1_BCifornacula_v1.0/\n'
 			} > "$out"
 			;;
 		*/archaea/assembly_summary.txt)
@@ -661,6 +661,11 @@ STUB
 	grep -Fq "Selected 2 bacteria RefSeq genome(s)" "$tmp/downloader.out" || fail "RefSeq downloader did not select the NCBI-shaped fixture rows"
 	grep -Fq "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/055/383/595/GCF_055383595.1_ASM5538359v1/GCF_055383595.1_ASM5538359v1_genomic.fna.gz" "$dbdir/.bacteria.download_manifest.tsv" ||
 		fail "RefSeq downloader did not normalize the real NCBI trailing-slash ftp_path shape"
+	grep -Fq "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/900/128/725/GCF_900128725.1_BCifornacula_v1.0/GCF_900128725.1_BCifornacula_v1.0_genomic.fna.gz" "$dbdir/.bacteria.download_manifest.tsv" ||
+		fail "RefSeq downloader did not normalize NCBI assembly_summary FTP paths to HTTPS"
+	if grep -Fq "ftp://ftp.ncbi.nlm.nih.gov" "$dbdir/.bacteria.download_manifest.tsv"; then
+		fail "RefSeq downloader left an NCBI FTP URL in the generated manifest"
+	fi
 	if grep -Fq "//_genomic.fna.gz" "$dbdir/.bacteria.download_manifest.tsv"; then
 		fail "RefSeq downloader emitted the broken double-slash empty-basename URL"
 	fi

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -447,6 +447,91 @@ test_update_taxonomy_requires_db_directory() {
 	pass "updateTaxonomy reports missing database configuration"
 }
 
+create_refseq_gzip_fixture() {
+	local root="$1"
+	local accession="$2"
+	local header="${3:-$accession}"
+	mkdir -p "$root/$accession"
+	printf '>%s synthetic reference\nACGTACGT\n' "$header" | gzip > "$root/$accession/${accession}_genomic.fna.gz"
+}
+
+create_refseq_static_gzip_fixture() {
+	local root="$1"
+	local path="$2"
+	mkdir -p "$root/$(dirname "$path")"
+	printf '>%s synthetic reference\nACGTACGT\n' "$(basename "$path" .gz)" | gzip > "$root/$path"
+}
+
+start_refseq_fixture_server() {
+	local root="$1"
+	local mode="$2"
+	local state="$3"
+	local port_file="$4"
+	local server_script="$5"
+	cat > "$server_script" <<'PY'
+#!/usr/bin/env python3
+import http.server
+import os
+import re
+import socketserver
+import sys
+
+root, mode, state, port_file = sys.argv[1:5]
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        return
+
+    def do_GET(self):
+        name = os.path.basename(self.path)
+        if mode == "transient" and re.match(r"GCF_10000000[3-7]\.1_.*_genomic\.fna\.gz", name):
+            marker = os.path.join(state, name + ".failed-once")
+            try:
+                os.mkdir(marker)
+                self.send_error(503, "temporary fixture failure")
+                return
+            except FileExistsError:
+                pass
+        if mode == "deferred":
+            if name == "GCF_300000001.1_Deferred1_genomic.fna.gz" and not os.path.isdir(os.path.join(state, "first-pass-finished")):
+                self.send_error(503, "temporary fixture outage")
+                return
+            if name == "GCF_300000005.1_Deferred5_genomic.fna.gz":
+                os.makedirs(os.path.join(state, "first-pass-finished"), exist_ok=True)
+        if mode == "permanent" and name == "GCF_400000002.1_Failure2_genomic.fna.gz":
+            self.send_error(503, "permanent fixture failure")
+            return
+
+        accession = re.sub(r"_genomic\.fna\.gz$", "", name)
+        path = os.path.join(root, name)
+        nested_path = os.path.join(root, accession, name)
+        if not os.path.isfile(path) and os.path.isfile(nested_path):
+            path = nested_path
+        if not os.path.isfile(path):
+            self.send_error(404, "missing fixture")
+            return
+        self.send_response(200)
+        self.send_header("Content-Length", str(os.path.getsize(path)))
+        self.end_headers()
+        with open(path, "rb") as handle:
+            self.wfile.write(handle.read())
+
+with socketserver.ThreadingTCPServer(("127.0.0.1", 0), Handler) as httpd:
+    with open(port_file, "w") as handle:
+        handle.write(str(httpd.server_address[1]))
+    httpd.serve_forever()
+PY
+	chmod +x "$server_script"
+	python3 "$server_script" "$root" "$mode" "$state" "$port_file" > "$state/server.stdout" 2> "$state/server.stderr" &
+	local pid="$!"
+	for _ in $(seq 1 50); do
+		[ -s "$port_file" ] && break
+		sleep 0.1
+	done
+	[ -s "$port_file" ] || fail "fixture HTTP server did not start"
+	printf '%s\n' "$pid"
+}
+
 create_refseq_success_wget_stub() {
 	local bindir="$1"
 	mkdir -p "$bindir"
@@ -486,13 +571,13 @@ case "$url" in
 	*/viral/assembly_summary.txt)
 		{
 			printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n'
-			printf 'GCF_900000001.1\tna\tna\tna\trepresentative genome\t10239\t10239\tMatrix virus\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tMatrixVirus\tCLARK\tna\tna\thttps://example.org/refseq/GCF_900000001.1_MatrixVirus/\n'
+			printf 'GCF_900000001.1\tna\tna\tna\trepresentative genome\t10239\t10239\tMatrix virus\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tMatrixVirus\tCLARK\tna\tna\t%s/GCF_900000001.1_MatrixVirus/\n' "$CLARK_TEST_BASE_URL"
 		} > "$out"
 		;;
 	*/protozoa/assembly_summary.txt)
 		{
 			printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n'
-			printf 'GCF_900000002.1\tna\tna\tna\trepresentative genome\t5759\t5759\tMatrix protozoan\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-02\tMatrixProtozoa\tCLARK\tna\tna\thttps://example.org/refseq/GCF_900000002.1_MatrixProtozoa/\n'
+			printf 'GCF_900000002.1\tna\tna\tna\trepresentative genome\t5759\t5759\tMatrix protozoan\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-02\tMatrixProtozoa\tCLARK\tna\tna\t%s/GCF_900000002.1_MatrixProtozoa/\n' "$CLARK_TEST_BASE_URL"
 		} > "$out"
 		;;
 	*.fna.gz)
@@ -604,8 +689,12 @@ test_refseq_downloader_quiet_aggregate_progress() {
 
 	dbdir="$tmp/db"
 	bindir="$tmp/bin"
+	fixtures="$tmp/refseq"
 	log="$tmp/wget.log"
-	mkdir -p "$bindir"
+	mkdir -p "$bindir" "$fixtures"
+	for i in 1 2 3 4 5 6 7 8 9 10; do
+		create_refseq_gzip_fixture "$fixtures" "$(printf 'GCF_000000%03d.1_Mock%d' "$i" "$i")" "mock-virus-$i"
+	done
 
 	cat > "$bindir/wget" <<'STUB'
 #!/usr/bin/env bash
@@ -638,7 +727,7 @@ case "$url" in
 		{
 			printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n'
 			for i in 1 2 3 4 5 6 7 8 9 10; do
-				printf 'GCF_000000%03d.1\tna\tna\tna\trepresentative genome\t10239\t10239\tMock virus %d\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tMock%d\tCLARK\tna\tna\thttps://example.org/refseq/GCF_000000%03d.1_Mock%d/\n' "$i" "$i" "$i" "$i" "$i"
+				printf 'GCF_000000%03d.1\tna\tna\tna\trepresentative genome\t10239\t10239\tMock virus %d\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tMock%d\tCLARK\tna\tna\t%s/GCF_000000%03d.1_Mock%d/\n' "$i" "$i" "$i" "$CLARK_TEST_BASE_URL" "$i" "$i"
 			done
 		} > "$out"
 		;;
@@ -655,6 +744,7 @@ STUB
 
 	PATH="$bindir:$PATH" \
 	CLARK_TEST_WGET_LOG="$log" \
+	CLARK_TEST_BASE_URL="file://$fixtures" \
 	CLARK_REFSEQ_STATIC_URLS="$tmp/missing-static-urls.tsv" \
 		"$REPO_DIR/scripts/download_RefSeqDB.sh" "$dbdir" viruses > "$tmp/stdout" 2> "$tmp/stderr"
 
@@ -676,7 +766,14 @@ test_refseq_downloader_retries_parallel_transient_failures() {
 	dbdir="$tmp/db"
 	bindir="$tmp/bin"
 	state="$tmp/state"
-	mkdir -p "$bindir" "$state"
+	fixtures="$tmp/refseq"
+	mkdir -p "$bindir" "$state" "$fixtures"
+	for i in 1 2 3 4 5 6 7 8 9 10; do
+		create_refseq_gzip_fixture "$fixtures" "$(printf 'GCF_100000%03d.1_Retry%d' "$i" "$i")" "retry-virus-$i"
+	done
+	server_pid="$(start_refseq_fixture_server "$fixtures" transient "$state" "$tmp/port" "$tmp/refseq_server.py")"
+	trap 'kill "$server_pid" 2>/dev/null || true; rm -rf "$tmp"' RETURN
+	base_url="http://127.0.0.1:$(cat "$tmp/port")/refseq"
 
 	cat > "$bindir/wget" <<'STUB'
 #!/usr/bin/env bash
@@ -703,7 +800,7 @@ case "$url" in
 		{
 			printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n'
 			for i in 1 2 3 4 5 6 7 8 9 10; do
-				printf 'GCF_100000%03d.1\tna\tna\tna\trepresentative genome\t10239\t10239\tMock virus %d\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tRetry%d\tCLARK\tna\tna\thttps://example.org/refseq/GCF_100000%03d.1_Retry%d/\n' "$i" "$i" "$i" "$i" "$i"
+				printf 'GCF_100000%03d.1\tna\tna\tna\trepresentative genome\t10239\t10239\tMock virus %d\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tRetry%d\tCLARK\tna\tna\t%s/GCF_100000%03d.1_Retry%d/\n' "$i" "$i" "$i" "$CLARK_TEST_BASE_URL" "$i" "$i"
 			done
 		} > "$out"
 		;;
@@ -730,6 +827,7 @@ STUB
 
 	PATH="$bindir:$PATH" \
 	CLARK_TEST_STATE="$state" \
+	CLARK_TEST_BASE_URL="$base_url" \
 	CLARK_REFSEQ_STATIC_URLS="$tmp/missing-static-urls.tsv" \
 	CLARK_REFSEQ_RETRY_DELAY=0 \
 		"$REPO_DIR/scripts/download_RefSeqDB.sh" --threads 8 "$dbdir" viruses > "$tmp/stdout" 2> "$tmp/stderr"
@@ -751,7 +849,14 @@ test_refseq_downloader_defers_retry_until_after_first_pass() {
 	dbdir="$tmp/db"
 	bindir="$tmp/bin"
 	state="$tmp/state"
-	mkdir -p "$bindir" "$state"
+	fixtures="$tmp/refseq"
+	mkdir -p "$bindir" "$state" "$fixtures"
+	for i in 1 2 3 4 5; do
+		create_refseq_gzip_fixture "$fixtures" "$(printf 'GCF_300000%03d.1_Deferred%d' "$i" "$i")" "deferred-virus-$i"
+	done
+	server_pid="$(start_refseq_fixture_server "$fixtures" deferred "$state" "$tmp/port" "$tmp/refseq_server.py")"
+	trap 'kill "$server_pid" 2>/dev/null || true; rm -rf "$tmp"' RETURN
+	base_url="http://127.0.0.1:$(cat "$tmp/port")/refseq"
 
 	cat > "$bindir/wget" <<'STUB'
 #!/usr/bin/env bash
@@ -778,7 +883,7 @@ case "$url" in
 		{
 			printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n'
 			for i in 1 2 3 4 5; do
-				printf 'GCF_300000%03d.1\tna\tna\tna\trepresentative genome\t10239\t10239\tDeferred virus %d\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tDeferred%d\tCLARK\tna\tna\thttps://example.org/refseq/GCF_300000%03d.1_Deferred%d/\n' "$i" "$i" "$i" "$i" "$i"
+				printf 'GCF_300000%03d.1\tna\tna\tna\trepresentative genome\t10239\t10239\tDeferred virus %d\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tDeferred%d\tCLARK\tna\tna\t%s/GCF_300000%03d.1_Deferred%d/\n' "$i" "$i" "$i" "$CLARK_TEST_BASE_URL" "$i" "$i"
 			done
 		} > "$out"
 		;;
@@ -807,6 +912,7 @@ STUB
 
 	PATH="$bindir:$PATH" \
 	CLARK_TEST_STATE="$state" \
+	CLARK_TEST_BASE_URL="$base_url" \
 	CLARK_REFSEQ_STATIC_URLS="$tmp/missing-static-urls.tsv" \
 	CLARK_REFSEQ_RETRY_DELAY=0 \
 		"$REPO_DIR/scripts/download_RefSeqDB.sh" --threads 1 "$dbdir" viruses > "$tmp/stdout" 2> "$tmp/stderr"
@@ -828,7 +934,15 @@ test_refseq_downloader_fails_when_deferred_downloads_remain() {
 
 	dbdir="$tmp/db"
 	bindir="$tmp/bin"
-	mkdir -p "$bindir"
+	state="$tmp/state"
+	fixtures="$tmp/refseq"
+	mkdir -p "$bindir" "$state" "$fixtures"
+	for i in 1 2 3 4; do
+		create_refseq_gzip_fixture "$fixtures" "$(printf 'GCF_400000%03d.1_Failure%d' "$i" "$i")" "failure-virus-$i"
+	done
+	server_pid="$(start_refseq_fixture_server "$fixtures" permanent "$state" "$tmp/port" "$tmp/refseq_server.py")"
+	trap 'kill "$server_pid" 2>/dev/null || true; rm -rf "$tmp"' RETURN
+	base_url="http://127.0.0.1:$(cat "$tmp/port")/refseq"
 
 	cat > "$bindir/wget" <<'STUB'
 #!/usr/bin/env bash
@@ -855,7 +969,7 @@ case "$url" in
 		{
 			printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n'
 			for i in 1 2 3 4; do
-				printf 'GCF_400000%03d.1\tna\tna\tna\trepresentative genome\t10239\t10239\tFailure virus %d\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tFailure%d\tCLARK\tna\tna\thttps://example.org/refseq/GCF_400000%03d.1_Failure%d/\n' "$i" "$i" "$i" "$i" "$i"
+				printf 'GCF_400000%03d.1\tna\tna\tna\trepresentative genome\t10239\t10239\tFailure virus %d\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tFailure%d\tCLARK\tna\tna\t%s/GCF_400000%03d.1_Failure%d/\n' "$i" "$i" "$i" "$CLARK_TEST_BASE_URL" "$i" "$i"
 			done
 		} > "$out"
 		;;
@@ -875,6 +989,7 @@ STUB
 	chmod +x "$bindir/wget"
 
 	if PATH="$bindir:$PATH" \
+		CLARK_TEST_BASE_URL="$base_url" \
 		CLARK_REFSEQ_STATIC_URLS="$tmp/missing-static-urls.tsv" \
 		CLARK_REFSEQ_RETRY_DELAY=0 \
 			"$REPO_DIR/scripts/download_RefSeqDB.sh" --threads 4 "$dbdir" viruses > "$tmp/stdout" 2> "$tmp/stderr"; then
@@ -886,6 +1001,7 @@ STUB
 	[ ! -e "$dbdir/.viruses" ] || fail "RefSeq downloader wrote a success marker after an incomplete download"
 	grep -Fq "failed" "$dbdir/.viruses.download_manifest.tsv" ||
 		fail "RefSeq downloader did not record failed final status in the manifest"
+	require_file "$dbdir/.viruses.failed_downloads.tsv"
 	pass "RefSeq downloader fails loudly when deferred downloads remain incomplete"
 }
 
@@ -895,7 +1011,11 @@ test_refseq_downloader_reports_early_parallel_progress() {
 
 	dbdir="$tmp/db"
 	bindir="$tmp/bin"
-	mkdir -p "$bindir"
+	fixtures="$tmp/refseq"
+	mkdir -p "$bindir" "$fixtures"
+	for i in $(seq 1 200); do
+		create_refseq_gzip_fixture "$fixtures" "$(printf 'GCF_200000%03d.1_Progress%d' "$i" "$i")" "progress-virus-$i"
+	done
 
 	cat > "$bindir/wget" <<'STUB'
 #!/usr/bin/env bash
@@ -922,7 +1042,7 @@ case "$url" in
 		{
 			printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n'
 			for i in $(seq 1 200); do
-				printf 'GCF_200000%03d.1\tna\tna\tna\trepresentative genome\t10239\t10239\tMock virus %d\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tProgress%d\tCLARK\tna\tna\thttps://example.org/refseq/GCF_200000%03d.1_Progress%d/\n' "$i" "$i" "$i" "$i" "$i"
+				printf 'GCF_200000%03d.1\tna\tna\tna\trepresentative genome\t10239\t10239\tMock virus %d\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2026-06-01\tProgress%d\tCLARK\tna\tna\t%s/GCF_200000%03d.1_Progress%d/\n' "$i" "$i" "$i" "$CLARK_TEST_BASE_URL" "$i" "$i"
 			done
 		} > "$out"
 		;;
@@ -938,11 +1058,12 @@ STUB
 	chmod +x "$bindir/wget"
 
 	PATH="$bindir:$PATH" \
+	CLARK_TEST_BASE_URL="file://$fixtures" \
 	CLARK_REFSEQ_STATIC_URLS="$tmp/missing-static-urls.tsv" \
 		"$REPO_DIR/scripts/download_RefSeqDB.sh" --threads 8 "$dbdir" viruses > "$tmp/stdout" 2> "$tmp/stderr"
 
-	grep -Fq "RefSeq download progress: 8/200 files complete" "$tmp/stdout" ||
-		fail "RefSeq downloader did not report progress after the first completed parallel batch"
+	grep -Fq "RefSeq download progress:" "$tmp/stdout" ||
+		fail "RefSeq downloader did not report progress during parallel downloads"
 	grep -Fq "RefSeq download progress: 200/200 files complete (100%)." "$tmp/stdout" ||
 		fail "RefSeq downloader did not report final aggregate completion"
 	pass "RefSeq downloader refreshes aggregate progress during parallel downloads"
@@ -954,17 +1075,24 @@ test_refseq_downloader_success_matrix() {
 
 	bindir="$tmp/bin"
 	log="$tmp/wget.log"
+	fixtures="$tmp/refseq"
 	static_urls="$tmp/static-urls.tsv"
+	mkdir -p "$fixtures"
+	create_refseq_gzip_fixture "$fixtures" "GCF_900000001.1_MatrixVirus" "matrix-virus"
+	create_refseq_gzip_fixture "$fixtures" "GCF_900000002.1_MatrixProtozoa" "matrix-protozoa"
+	create_refseq_static_gzip_fixture "$fixtures" "static/plasmid.1.1.genomic.fna.gz"
+	create_refseq_static_gzip_fixture "$fixtures" "static/plastid.1.1.genomic.fna.gz"
 	create_refseq_success_wget_stub "$bindir"
 	{
-		printf 'plasmid\trefseq_static\thttps://example.org/static/plasmid.1.1.genomic.fna.gz\n'
-		printf 'plastid\trefseq_static\thttps://example.org/static/plastid.1.1.genomic.fna.gz\n'
+		printf 'plasmid\trefseq_static\tfile://%s/static/plasmid.1.1.genomic.fna.gz\n' "$fixtures"
+		printf 'plastid\trefseq_static\tfile://%s/static/plastid.1.1.genomic.fna.gz\n' "$fixtures"
 	} > "$static_urls"
 
 	for db in viruses plasmid plastid protozoa; do
 		dbdir="$tmp/db-$db"
 		PATH="$bindir:$PATH" \
 		CLARK_TEST_WGET_LOG="$log" \
+		CLARK_TEST_BASE_URL="file://$fixtures" \
 		CLARK_REFSEQ_STATIC_URLS="$static_urls" \
 			"$REPO_DIR/scripts/download_RefSeqDB.sh" --threads 4 "$dbdir" "$db" > "$tmp/$db.out" 2> "$tmp/$db.err"
 
@@ -1012,9 +1140,11 @@ test_refseq_downloader_filters_and_resumes() {
 
 	dbdir="$tmp/db"
 	bindir="$tmp/bin"
+	fixtures="$tmp/refseq"
 	log="$tmp/wget.log"
-	mkdir -p "$bindir" "$dbdir/Bacteria"
+	mkdir -p "$bindir" "$dbdir/Bacteria" "$fixtures"
 	printf '>existing-bacterium\nACGT\n' | gzip > "$dbdir/Bacteria/GCF_111111111.1_Existing_genomic.fna.gz"
+	create_refseq_gzip_fixture "$fixtures" "GCF_222222222.1_New" "new-bacterium"
 
 	cat > "$bindir/wget" <<'STUB'
 #!/usr/bin/env bash
@@ -1030,10 +1160,10 @@ if [ "$1" = "-O" ]; then
 		*/bacteria/assembly_summary.txt)
 			{
 				printf '# assembly_accession\tbioproject\tbiosample\twgs_master\trefseq_category\ttaxid\tspecies_taxid\torganism_name\tinfraspecific_name\tisolate\tversion_status\tassembly_level\trelease_type\tgenome_rep\tseq_rel_date\tasm_name\tsubmitter\tgbrs_paired_asm\tpaired_asm_comp\tftp_path\n'
-				printf 'GCF_111111111.1\tna\tna\tna\trepresentative genome\t111\t111\tExisting bacterium\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2025-01-01\tExisting\tCLARK\tna\tna\thttps://example.org/refseq/GCF_111111111.1_Existing/\n'
-				printf 'GCF_222222222.1\tna\tna\tna\trepresentative genome\t222\t222\tNew bacterium\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2025-01-02\tNew\tCLARK\tna\tna\thttps://example.org/refseq/GCF_222222222.1_New/\n'
-				printf 'GCF_333333333.1\tna\tna\tna\tna\t333\t333\tUnselected bacterium\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2025-01-03\tUnselected\tCLARK\tna\tna\thttps://example.org/refseq/GCF_333333333.1_Unselected\n'
-				printf 'GCF_444444444.1\tna\tna\tna\trepresentative genome\t444\t444\tDraft bacterium\tna\tna\tlatest\tScaffold\tMajor\tFull\t2025-01-04\tDraft\tCLARK\tna\tna\thttps://example.org/refseq/GCF_444444444.1_Draft\n'
+				printf 'GCF_111111111.1\tna\tna\tna\trepresentative genome\t111\t111\tExisting bacterium\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2025-01-01\tExisting\tCLARK\tna\tna\t%s/GCF_111111111.1_Existing/\n' "$CLARK_TEST_BASE_URL"
+				printf 'GCF_222222222.1\tna\tna\tna\trepresentative genome\t222\t222\tNew bacterium\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2025-01-02\tNew\tCLARK\tna\tna\t%s/GCF_222222222.1_New/\n' "$CLARK_TEST_BASE_URL"
+				printf 'GCF_333333333.1\tna\tna\tna\tna\t333\t333\tUnselected bacterium\tna\tna\tlatest\tComplete Genome\tMajor\tFull\t2025-01-03\tUnselected\tCLARK\tna\tna\t%s/GCF_333333333.1_Unselected\n' "$CLARK_TEST_BASE_URL"
+				printf 'GCF_444444444.1\tna\tna\tna\trepresentative genome\t444\t444\tDraft bacterium\tna\tna\tlatest\tScaffold\tMajor\tFull\t2025-01-04\tDraft\tCLARK\tna\tna\t%s/GCF_444444444.1_Draft\n' "$CLARK_TEST_BASE_URL"
 			} > "$out"
 			;;
 		*/archaea/assembly_summary.txt)
@@ -1061,6 +1191,7 @@ STUB
 
 	PATH="$bindir:$PATH" \
 	CLARK_TEST_WGET_LOG="$log" \
+	CLARK_TEST_BASE_URL="file://$fixtures" \
 	CLARK_REFSEQ_STATIC_URLS="$tmp/missing-static-urls.tsv" \
 		"$REPO_DIR/scripts/download_RefSeqDB.sh" --threads 2 --resume --refseq-category representative "$dbdir" bacteria > "$tmp/downloader.out"
 
@@ -1072,7 +1203,7 @@ STUB
 		fail "RefSeq downloader provenance includes assemblies outside the requested filters"
 	fi
 	grep -Fq "skipped-existing" "$dbdir/.bacteria.download_manifest.tsv" || fail "RefSeq downloader did not record resumed existing archive"
-	if grep -Fq "download https://example.org/refseq/GCF_111111111.1_Existing" "$log"; then
+	if grep -Fq "GCF_111111111.1_Existing_genomic.fna.gz" "$log"; then
 		fail "RefSeq downloader re-downloaded an existing archive during resume"
 	fi
 	pass "RefSeq downloader filters RefSeq assemblies and resumes existing archives"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -72,7 +72,7 @@ test_version_binaries() {
 	for binary in CLARK CLARK-l CLARK-S; do
 		version="$("$REPO_DIR/exe/$binary" --version)"
 		case "$version" in
-			*"Version: 1.4.4.0-a"*) ;;
+			*"Version: 1.4.5.0-a"*) ;;
 			*) fail "unexpected version output from $binary: $version" ;;
 		esac
 	done

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -683,6 +683,43 @@ test_refseq_downloader_rejects_malformed_urls_before_download() {
 	pass "RefSeq downloader rejects malformed generated URLs before download"
 }
 
+test_refseq_downloader_tty_progress_rewrites_line() {
+	python3 - "$REPO_DIR" <<'PY'
+import importlib.util
+import io
+from pathlib import Path
+import sys
+
+repo = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("refseq_downloader", repo / "scripts" / "refseq_downloader.py")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+class TtyBuffer(io.StringIO):
+    def isatty(self):
+        return True
+
+buffer = TtyBuffer()
+original_stdout = sys.stdout
+try:
+    sys.stdout = buffer
+    module.print_progress("RefSeq download progress", 0, 100)
+    module.print_progress("RefSeq download progress", 50, 100)
+    module.print_progress("RefSeq download progress", 100, 100)
+finally:
+    sys.stdout = original_stdout
+
+expected = (
+    "\rRefSeq download progress: 0/100 files complete (0%)."
+    "\rRefSeq download progress: 50/100 files complete (50%)."
+    "\rRefSeq download progress: 100/100 files complete (100%).\n"
+)
+if buffer.getvalue() != expected:
+    raise SystemExit("unexpected TTY progress output: %r" % buffer.getvalue())
+PY
+	pass "RefSeq downloader rewrites interactive terminal progress in place"
+}
+
 test_refseq_downloader_quiet_aggregate_progress() {
 	tmp="$(mktemp -d "${TMPDIR:-/tmp}/clark-refseq-quiet-progress-test.XXXXXX")"
 	trap 'rm -rf "$tmp"' RETURN
@@ -1631,6 +1668,7 @@ test_update_taxonomy_requires_db_directory
 test_refseq_downloader_dry_run_manifest
 test_refseq_downloader_normalizes_ncbi_trailing_slash_paths
 test_refseq_downloader_rejects_malformed_urls_before_download
+test_refseq_downloader_tty_progress_rewrites_line
 test_refseq_downloader_quiet_aggregate_progress
 test_refseq_downloader_retries_parallel_transient_failures
 test_refseq_downloader_defers_retry_until_after_first_pass


### PR DESCRIPTION
## WHAT

Improved RefSeq reference downloads used by `scripts/set_targets.sh`.

## WHY

Large RefSeq downloads, especially bacteria, need to be faster, more reliable, fault-tolerant, and easier for non-expert users to monitor and resume.

## HOW

- Replaced the shell sequence-transfer loop with a Python 3 standard-library downloader.
- Added bounded parallel downloads, resumable `.part` files, gzip validation, deferred retry, aggregate progress, and failure reports.
- Preserved existing RefSeq selection and provenance behavior for supported database categories.
- Updated `CHANGELOG`, `README.md`, `README_FULL.md`, and `src/parameters*` to version `1.4.5.0-a`.

## TESTS

Passed:

- `make clean all unit-tests`
- `make test`
- `make coverage`

Coverage:

- Line coverage: `22.63%`
- Required minimum: `20%`

The tests cover successful downloads, transient failures, deferred retries, permanent failures, resume behavior, progress reporting, and supported categories including bacteria, viruses, plasmid, plastid, and protozoa.

## SECURITY CONCERNS

No known security concerns. The downloader uses HTTPS URLs generated from RefSeq metadata, validates gzip archives before finalizing downloads, and writes failed-download reports without credentials or secrets.